### PR TITLE
Use async await for verify route and add decorator

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,7 @@ env:
   mocha: true
 extends: 'eslint:recommended'
 parserOptions:
+  ecmaVersion: 2017
   ecmaFeatures:
     experimentalObjectRestSpread: true
     jsx: true


### PR DESCRIPTION
## Description
This PR refactors the verify endpoint to use async/await syntax. The advantages of using async/await are that the code is much more readable and we can avoid the convoluted structure of both callbacks and promises.

## Test Plan
Send a request to this endpoint and the response should be the pregnancy center with the added `pregnancyCenterUser` object. 

Note - linting fails on this because of the new syntax. eslint updates will need to be made.
