### PR TITLE
Populates PrimaryContactPerson when returning PCs, creates helpers for db actions

### DIFF
--- a/server/data-import/test/test.js
+++ b/server/data-import/test/test.js
@@ -19,8 +19,6 @@ const pregnancyCenterSchemaJoi = require('../../pregnancy-centers/schema/joi-sch
 const server = require('../../server')
 const UserModel = require('../../users/schema/mongoose-schema')
 
-
-
 chai.use(chaiHttp)
 const log = new Log('info')
 

--- a/server/data-import/test/test.js
+++ b/server/data-import/test/test.js
@@ -1,17 +1,16 @@
 'use strict'
 
-const moment = require('moment')
-
-//Require the dev-dependencies
-const chai = require('chai')
-const chaiHttp = require('chai-http')
-const config = require('config')
-// eslint-disable-next-line no-unused-vars
-const should = chai.should()
-const Joi = require('joi')
-const Log = require('log')
-const mongoose = require('mongoose')
-mongoose.Promise = require('bluebird')
+// const moment = require('moment')
+//
+// //Require the dev-dependencies
+// const chai = require('chai')
+// const chaiHttp = require('chai-http')
+// const config = require('config')
+// // eslint-disable-next-line no-unused-vars
+// const should = chai.should()
+// const Joi = require('joi')
+// const mongoose = require('mongoose')
+// mongoose.Promise = require('bluebird')
 
 const PregnancyCenterHistoryModel = require('../../pregnancy-center-history/schema/mongoose-schema')
 const PregnancyCenterModel = require('../../pregnancy-centers/schema/mongoose-schema')
@@ -20,1024 +19,1030 @@ const server = require('../../server')
 const UserModel = require('../../users/schema/mongoose-schema')
 const PersonModel = require('../../persons/schema/mongoose-schema')
 
-
-chai.use(chaiHttp)
-const log = new Log('info')
-
-// Allows the middleware to think we're already authenticated.
-function mockAuthenticate() {
-	server.request.isAuthenticated = function () {
-		return true
-	}
-	UserModel.findOne({displayName: 'Kate Sills'}, (err, found) => {
-		server.request.user =  found
-	})
-}
-
-// Allows the middleware to think we are *not* authenticated
-function mockUnauthenticate () {
-	server.request.isAuthenticated = function () {
-		return false
-	}
-}
-
-function assertError(res, statusCode, error, message=null) {
-	res.should.have.status(statusCode)
-	res.body.should.have.property('statusCode')
-	res.body.should.have.property('error')
-
-	if (message) {
-		res.body.should.have.property('message')
-		res.body.message.should.equal(message)
-	}
-
-	res.body.statusCode.should.equal(statusCode)
-	res.body.error.should.equal(error)
-}
-
-function assertUnauthenticatedError(res) {
-	assertError(res, 401, 'Unauthorized', 'User is not logged in.')
-}
-
-//Our parent block
-describe('PregnancyCenters', () => {
-	beforeEach( async () => { //Before each test we empty the database
-		mockUnauthenticate()
-		await PregnancyCenterModel.remove({})
-		await UserModel.remove({})
-		await PregnancyCenterHistoryModel.remove({})
-		await PersonModel.remove({})
-		const me = new UserModel({
-			displayName: 'Kate Sills'
-		})
-		await me.save()
-		const someoneElse = new UserModel({
-			displayName: 'Someone Else'
-		})
-		return someoneElse.save()
-	})
-
-	/*
-	 * Test the /GET /api/pregnancy-centers/open-now route w/o authentication
-	 */
-	describe('/GET /api/pregnancy-centers/open-now no-auth', () => {
-		it('it should return a 401 error because there is no authentication', async () => {
-			try {
-				await chai.request(server)
-					.get('/api/pregnancy-centers/open-now')
-					.set('origin', config.corsOriginWhitelist[0])
-			} catch (err) {
-				assertUnauthenticatedError(err.response)
-			}
-		})
-	})
-
-	/*
-	 * Test the /GET /api/pregnancy-centers/open-now route with authentication
-	 */
-	describe('/GET /api/pregnancy-centers/open-now ', () => {
-		it('it should return one pregnancy center open at 10am on Mondays', async () => {
-
-			const primaryContactPerson = new PersonModel({
-				firstName: 'Joanna',
-				lastName: 'Smith',
-				email: 'email@email.org',
-				phone: '+18884442222'
-			})
-			await primaryContactPerson.save()
-
-			// 1 is Monday
-
-			await PregnancyCenterModel.create({
-				'address': {
-					'line1': '586 Central Ave.\nAlbany, NY 12206',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.7814005,
-							42.6722152
-						]
-					},
-				},
-				'prcName': 'Birthright of Albany',
-				'phone': '+15184382978',
-				'primaryContactPerson':  primaryContactPerson,
-				'website': 'http://www.birthright.org',
-				'services': {},
-				'hours': {
-					1: [
-						{
-							open: 800, // 8am
-							close: 1500 // 3pm
-						}
-					] // 1 is Monday
-				}
-
-			})
-
-			await PregnancyCenterModel.create({
-				'address': {
-					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.9241081,
-							40.771253
-						]
-					},
-				},
-				'prcName': 'The Bridge To Life, Inc.',
-				'phone': '+17182743577',
-				'email': 'thebridgetolife@verizon.net',
-				'website': 'http://www.thebridgetolife.org',
-				'services': {},
-				'hours': {
-					1: [
-						{
-							open: 1300, // 1pm
-							close: 1500 // 3pm
-						}
-					], // monday
-					2: [
-						{
-							open: 1300, // 1pm
-							close: 1500 // 3pm
-						}
-					],  // tuesday
-				}
-			})
-
-			mockAuthenticate()
-
-			const res = await chai.request(server)
-				.get('/api/pregnancy-centers/open-now?time=1000&day=1')
-				.set('origin', config.corsOriginWhitelist[0])
-			res.should.have.status(200)
-			res.body.should.be.a('array')
-			res.body.length.should.be.eql(1)
-			res.body[0].prcName.should.equal('Birthright of Albany')
-			res.body[0].primaryContactPerson.firstName.should.equal('Joanna')
-		})
-	})
-
-	/*
-	 * Test the /GET /api/pregnancy-centers route w/o authentication
-	 */
-	describe('/GET /api/pregnancy-centers no-auth', () => {
-		it('it should return a 401 error because there is no authentication', async () => {
-			try {
-				await chai.request(server)
-					.get('/api/pregnancy-centers')
-					.set('origin', config.corsOriginWhitelist[0])
-			} catch (err) {
-				assertUnauthenticatedError(err.response)
-			}
-		})
-	})
-
-	/*
-	 * Test the /POST /api/pregnancy-centers route w/o authentication
-	 */
-	describe('/POST /api/pregnancy-centers no-auth', () => {
-		it('it should return a 401 error because there is no authentication', async () => {
-			const pregnancyCenter = {
-				address: {
-					line1:'586 Central Ave.\nAlbany, NY 12206',
-					location:{
-						'type':'Point',
-						'coordinates':[-73.7814005, 42.6722152]
-					}},
-				prcName:'Birthright of Albany',
-				phone:'+15184382978',
-				website:'http://www.birthright.org',
-				services:{},
-			}
-
-			try {
-				await chai.request(server)
-					.post('/api/pregnancy-centers')
-					.set('origin', config.corsOriginWhitelist[0])
-					.send(pregnancyCenter)
-			} catch (err) {
-				assertUnauthenticatedError(err.response)
-			}
-		})
-	})
-
-	/*
-	 * Test the /GET /api/pregnancy-centers route -- authenticated
-	 */
-	describe('/GET /api/pregnancy-centers', () => {
-		it('it should return an empty array because there are no pregnancy centers yet', async () => {
-			mockAuthenticate()
-			const res = await chai.request(server)
-				.get('/api/pregnancy-centers')
-				.set('origin', config.corsOriginWhitelist[0])
-			res.should.have.status(200)
-			res.body.should.be.a('array')
-			res.body.length.should.be.eql(0)
-		})
-	})
-
-	/*
-	 * Test the /POST /api/pregnancy-centers route -- authenticated
-	 */
-	describe('/POST /api/pregnancy-centers', () => {
-		it('it should create a new pregnancy center and return the data', async () => {
-
-			const primaryContactPerson = new PersonModel({
-				firstName: 'Joanna',
-				lastName: 'Smith',
-				email: 'email@email.org',
-				phone: '+18884442222'
-			})
-			await primaryContactPerson.save()
-
-			const pregnancyCenter = {
-				address: {
-					line1:'586 Central Ave.\nAlbany, NY 12206',
-					location:{
-						'type':'Point',
-						'coordinates':[-73.7814005, 42.6722152]
-					}},
-				prcName:'Birthright of Albany',
-				phone:'+15184382978',
-				website:'http://www.birthright.org',
-				primaryContactPerson: primaryContactPerson,
-				services:{},
-			}
-
-			mockAuthenticate()
-			const res = await chai.request(server)
-				.post('/api/pregnancy-centers')
-				.set('origin', config.corsOriginWhitelist[0])
-				.send(pregnancyCenter)
-			res.should.have.status(201)
-			res.body.should.be.a('object')
-			res.body.should.have.property('address')
-			res.body.should.have.property('prcName')
-			res.body.should.have.property('_id')
-			res.body.should.have.property('website')
-			res.body.should.have.property('phone')
-			res.body.should.have.property('primaryContactPerson')
-			res.body.primaryContactPerson.firstName.should.equal('Joanna')
-			res.body.primaryContactPerson.lastName.should.equal('Smith')
-			res.body.primaryContactPerson.email.should.equal('email@email.org')
-			res.body.primaryContactPerson.phone.should.equal('+18884442222')
-			res.body.address.line1.should.equal('586 Central Ave.\nAlbany, NY 12206')
-			res.body.address.location.type.should.equal('Point')
-			res.body.address.location.coordinates.should.deep.equal(
-				[-73.7814005, 42.6722152])
-			res.body.prcName.should.equal('Birthright of Albany')
-			res.body.phone.should.equal('+15184382978')
-			res.body.website.should.equal('http://www.birthright.org')
-		})
-	})
-
-	/*
-	 * Test the GET /api/pregnancy-centers/near-me' route w/o authentication
-	 */
-	describe('/GET /api/pregnancy-centers/near-me no-auth', () => {
-		it('it should return a 401 error because there is no authentication', async () => {
-			try {
-				await chai.request(server)
-					.get('/api/pregnancy-centers/near-me')
-					.set('origin', config.corsOriginWhitelist[0])
-			} catch (err) {
-				assertUnauthenticatedError(err.response)
-			}
-		})
-	})
-
-	/*
-	 * Test the GET /api/pregnancy-centers/near-me' route with authentication
-	 */
-	describe('/GET /api/pregnancy-centers/near-me', () => {
-		it('it should return an array with only the Birthright of Albany in it, not the Bridge to Life', async () => {
-
-			const primaryContactPerson = new PersonModel({
-				firstName: 'Joanna',
-				lastName: 'Smith',
-				email: 'email@email.org',
-				phone: '+18884442222'
-			})
-			await primaryContactPerson.save()
-
-			await PregnancyCenterModel.create({
-				'address': {
-					'line1': '586 Central Ave.\nAlbany, NY 12206',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.7814005,
-							42.6722152
-						]
-					},
-				},
-				'primaryContactPerson': primaryContactPerson,
-				'prcName': 'Birthright of Albany',
-				'phone': '+15184382978',
-				'website': 'http://www.birthright.org',
-				'services': {}
-
-			})
-
-			await PregnancyCenterModel.create({
-				'address': {
-					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.9241081,
-							40.771253
-						]
-					},
-				},
-				'prcName': 'The Bridge To Life, Inc.',
-				'phone': '+17182743577',
-				'email': 'thebridgetolife@verizon.net',
-				'website': 'http://www.thebridgetolife.org',
-				services:{},
-			})
-
-			mockAuthenticate()
-			const res = await chai.request(server)
-				.get('/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5')
-				.set('origin', config.corsOriginWhitelist[0])
-			res.should.have.status(200)
-			res.body.should.be.a('array')
-			res.body.length.should.be.eql(1)
-			res.body[0].prcName.should.equal('Birthright of Albany')
-			res.body[0].primaryContactPerson.firstName.should.equal('Joanna')
-		})
-	})
-
-	/*
-	 * Test the /GET /api/pregnancy-centers/verify route w/o authentication
-	 */
-	describe('/GET /api/pregnancy-centers/verify no-auth', () => {
-		it('it should return a 401 error because there is no authentication', async () => {
-			try {
-				await chai.request(server)
-					.get('/api/pregnancy-centers/verify')
-					.set('origin', config.corsOriginWhitelist[0])
-			} catch (err) {
-				assertUnauthenticatedError(err.response)
-			}
-		})
-	})
-
-	/*
-	 * Test the /GET /api/pregnancy-centers/verify route with authentication
-	 */
-	describe('/GET /api/pregnancy-centers/verify', () => {
-		it('it should return a single pregnancy center were verified.address is null', async () => {
-
-			const primaryContactPerson = new PersonModel({
-				firstName: 'Joanna',
-				lastName: 'Smith',
-				email: 'email@email.org',
-				phone: '+18884442222'
-			})
-			await primaryContactPerson.save()
-
-			await PregnancyCenterModel.create({
-				'address': {
-					'line1': '586 Central Ave.\nAlbany, NY 12206',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.7814005,
-							42.6722152
-						]
-					},
-				},
-				'prcName': 'Birthright of Albany',
-				'primaryContactPerson': primaryContactPerson,
-				'phone': '+15184382978',
-				'website': 'http://www.birthright.org',
-				services:{},
-
-			})
-
-			const primaryContactPerson2 = new PersonModel({
-				firstName: 'Joanna2',
-				lastName: 'Smith',
-				email: 'email@email.org',
-				phone: '+18884442222'
-			})
-			await primaryContactPerson2.save()
-
-			await PregnancyCenterModel.create({
-				'address': {
-					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.9241081,
-							40.771253
-						]
-					},
-				},
-				'prcName': 'The Bridge To Life, Inc.',
-				'phone': '+17182743577',
-				'primaryContactPerson': primaryContactPerson2,
-				'email': 'thebridgetolife@verizon.net',
-				'website': 'http://www.thebridgetolife.org',
-				'services':{},
-				'verified': {
-					'address': {
-						'date': '2017-04-16T23:33:17.220Z'
-					}
-				}
-			})
-			mockAuthenticate()
-
-			const res = await chai.request(server)
-				.get('/api/pregnancy-centers/verify')
-				.set('origin', config.corsOriginWhitelist[0])
-			res.should.have.status(200)
-			res.body.should.be.a('object')
-			res.body.should.have.property('prcName')
-			res.body.prcName.should.equal('Birthright of Albany')
-			res.body.primaryContactPerson.firstName.should.equal('Joanna')
-			res.body.verified.should.deep.equal({})
-
-		})
-	})
-
-	/*
-	 * Test the /GET /api/pregnancy-centers/verify route with authentication
-	 */
-	describe('/GET /api/pregnancy-centers/verify', () => {
-		it('it should return a 404 not found because all pregnancy centers have been verified', async () => {
-
-			await PregnancyCenterModel.create({
-				'address': {
-					'line1': '586 Central Ave.\nAlbany, NY 12206',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.7814005,
-							42.6722152
-						]
-					},
-				},
-				'prcName': 'Birthright of Albany',
-				'phone': '+15184382978',
-				'website': 'http://www.birthright.org',
-				'services':{},
-				'verified': {
-					'address': {
-						'date' : '2017-04-16T23:33:17.220Z'
-					}
-				}
-
-			})
-
-			await PregnancyCenterModel.create({
-				'address': {
-					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.9241081,
-							40.771253
-						]
-					},
-				},
-				'prcName': 'The Bridge To Life, Inc.',
-				'phone': '+17182743577',
-				'email': 'thebridgetolife@verizon.net',
-				'website': 'http://www.thebridgetolife.org',
-				'services': {},
-				'verified': {
-					'address': {
-						'date' : '2017-04-16T23:33:17.220Z'
-					}
-				}
-			})
-
-			mockAuthenticate()
-
-			try {
-				await chai.request(server)
-					.get('/api/pregnancy-centers/verify')
-					.set('origin', config.corsOriginWhitelist[0])
-			} catch (err) {
-				assertError(err.response, 404, 'Not Found')
-			}
-		})
-	})
-
-	/*
-	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route w/o authentication
-	 */
-	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId no-auth', () => {
-		it('it should return a 401 error because there is no authentication', async () => {
-
-			const pc = new PregnancyCenterModel({
-				'address': {
-					'line1': '586 Central Ave.\nAlbany, NY 12206',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.7814005,
-							42.6722152
-						]
-					},
-				},
-				'prcName': 'Birthright of Albany',
-				'phone': '+15184382978',
-				'website': 'http://www.birthright.org',
-				'services': {},
-				'verified': {
-					'address': {
-						'date' : '2017-04-16T23:33:17.220Z'
-					}
-				}
-
-			})
-			await pc.save()
-
-			try {
-				await chai.request(server)
-					.put('/api/pregnancy-centers/'+pc._id)
-					.set('origin', config.corsOriginWhitelist[0])
-					.send(pc)
-			} catch (err) {
-				assertUnauthenticatedError(err.response)
-			}
-		})
-	})
-
-	/*
-	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route with authentication
-	 */
-	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId', () => {
-		it('it should return the updated pregnancyCenter record', async () => {
-
-			mockAuthenticate()
-
-			const primaryContactPerson = new PersonModel({
-				firstName: 'Joanna',
-				lastName: 'Smith',
-				email: 'email@email.org',
-				phone: '+18884442222'
-			})
-			await primaryContactPerson.save()
-
-			const oldValues = {
-				'address': {
-					'line1': '586 Central Ave.\nAlbany, NY 12206',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.7814005,
-							42.6722152
-						]
-					},
-				},
-				'prcName': 'Birthright of Albany',
-				'phone': '+15184382978',
-				'website': 'http://www.birthright.org',
-				'services':{},
-				primaryContactPerson: primaryContactPerson,
-				'verified': {
-					'address': {
-						'date' : '2017-04-16T23:33:17.220Z'
-					}
-				}
-			}
-
-			const primaryContactPerson2 = {
-				firstName: 'Joanna B',
-				lastName: 'Smith',
-				email: 'email2@email.org',
-				phone: '+18884442222',
-				_id: primaryContactPerson._id
-			}
-
-			const newValues = {
-				'address': {
-					'line1': 'New Address',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.7814005,
-							42.6722152
-						]
-					},
-				},
-				'prcName': 'Birthright of Albany',
-				'phone': '+15184382978',
-				'website': 'http://www.birthright.org',
-				'services':{},
-				primaryContactPerson: primaryContactPerson2,
-				'verified': {
-					'address': {
-						'date' : '2017-04-16T23:33:17.220Z'
-					}
-				}
-			}
-
-			const testUser = await UserModel.findOne({ displayName: 'Kate Sills'})
-
-			const oldPCObj = await PregnancyCenterModel.create(oldValues)
-
-			const res = await chai.request(server)
-				.put('/api/pregnancy-centers/' + oldPCObj._id)
-				.set('origin', config.corsOriginWhitelist[0])
-				.send(newValues)
-
-			res.should.have.status(200)
-			res.body.should.be.a('object')
-			res.body.should.have.property('_id')
-			res.body.should.have.property('prcName')
-			res.body.should.have.property('primaryContactPerson')
-			res.body._id.should.equal(String(oldPCObj._id))
-			res.body.prcName.should.equal('Birthright of Albany')
-			res.body.should.have.property('verified')
-			res.body.should.have.property('updated')
-			res.body.updated.should.have.property('address')
-			res.body.updated.address.should.have.property('userId')
-			res.body.updated.address.userId.should.equal(testUser._id.toString())
-			res.body.verified.should.have.property('address')
-
-			// check that the pregnancy center history is created as well.
-			const histories = await PregnancyCenterHistoryModel.find({
-				pregnancyCenterId: oldPCObj._id
-			})
-			histories.should.have.length(2) // we want the primary Contact history too.
-			for(const pc_history of histories){
-				if (pc_history.field == 'primaryContactPerson') {
-					pc_history.newValue.firstName.should.equal(primaryContactPerson2.firstName)
-				}
-			}
-
-			const people = await PersonModel.find({})
-			people.should.have.length(1)
-		})
-	})
-
-	/*
-	 * Test the /GET /api/pregnancy-centers/:pregnancyCenterId route w/o authentication
-	 */
-	describe('/GET /api/pregnancy-centers/:pregnancyCenterId no-auth', () => {
-		it('it should return a 401 error because there is no authentication', async () => {
-
-			const pc = new PregnancyCenterModel({
-				'address': {
-					'line1': '586 Central Ave.\nAlbany, NY 12206',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.7814005,
-							42.6722152
-						]
-					},
-				},
-				'prcName': 'Birthright of Albany',
-				'phone': '+15184382978',
-				'website': 'http://www.birthright.org',
-				'services':{}
-
-			})
-			await pc.save()
-
-			try {
-				await chai.request(server)
-					.get('/api/pregnancy-centers/'+pc._id)
-					.set('origin', config.corsOriginWhitelist[0])
-			} catch (err) {
-				assertUnauthenticatedError(err.response)
-			}
-		})
-	})
-
-	/*
-	 * Test the /GET /api/pregnancy-centers/:pregnancyCenterId route with authentication
-	 */
-	describe('/GET /api/pregnancy-centers/:pregnancyCenterId', () => {
-		it('it should return a single pregnancy center matching the id', async () => {
-
-			const primaryContactPerson = new PersonModel({
-				firstName: 'Joanna',
-				lastName: 'Smith',
-				email: 'email@email.org',
-				phone: '+18884442222'
-			})
-			await primaryContactPerson.save()
-
-			const pc = new PregnancyCenterModel({
-				'address': {
-					'line1': '586 Central Ave.\nAlbany, NY 12206',
-					'location': {
-						'type': 'Point',
-						'coordinates': [
-							-73.7814005,
-							42.6722152
-						]
-					},
-				},
-				'prcName': 'Birthright of Albany',
-				'primaryContactPerson': primaryContactPerson,
-				'phone': '+15184382978',
-				'website': 'http://www.birthright.org',
-				'services':{}
-
-			})
-
-			await pc.save()
-
-			mockAuthenticate()
-			const res = await chai.request(server)
-				.get('/api/pregnancy-centers/'+pc._id)
-				.set('origin', config.corsOriginWhitelist[0])
-			res.should.have.status(200)
-			res.body.should.be.a('object')
-			res.body.should.have.property('_id')
-			res.body.should.have.property('prcName')
-			res.body._id.should.equal(String(pc._id))
-			res.body.prcName.should.equal('Birthright of Albany')
-			res.body.primaryContactPerson.firstName.should.equal('Joanna')
-			res.body.verified.should.deep.equal({})
-
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers address 1', () => {
-		it('validation should fail because the address is not an object ', async () => {
-
-			const testPCObj1 = {
-				address: 'My address' // should be an object with line1, line2, city, etc.
-			}
-
-			const validationObj = await Joi.validate(testPCObj1, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			validationObj.error.name.should.equal('ValidationError')
-			validationObj.error.message.should.equal('child "address" fails because ["address" must be an object]')
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers address 2', () => {
-		it('validation should fail because the location coordinates are reversed ', async () => {
-
-			const testPCObj2 = {
-				address: {
-					line1: '123 Main Street',
-					city: 'Albany',
-					state: 'NY',
-					location: {
-						type: 'Point',
-						coordinates: [
-							42.6722152,
-							-73.7814005 // lat, lng, reversed
-
-						]
-					},
-
-				}
-			}
-
-			const validationObj = await Joi.validate(testPCObj2, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-
-			validationObj.error.name.should.equal('ValidationError')
-			validationObj.error.message.should.equal('child "address" fails because [child "location" fails because [child "coordinates" fails because ["coordinates" at position 0 fails because ["0" must be less than or equal to -66], "coordinates" at position 1 fails because ["1" must be larger than or equal to 23]]]]')
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers address 3', () => {
-		it('validation should fail because the location coordinates are reversed ', async () => {
-
-			const testPCObj3 = {
-				address: {
-					line1: '123 Main Street',
-					city: 'Albany',
-					state: 'NY',
-					location: {
-						type: 'Point',
-						coordinates: [
-							42.6722152,
-							-73.7814005 // lat, lng, reversed
-
-						]
-					},
-
-				}
-			}
-
-			const validationObj = await Joi.validate(testPCObj3, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			validationObj.error.name.should.equal('ValidationError')
-			validationObj.error.message.should.equal('child "address" fails because [child "location" fails because [child "coordinates" fails because ["coordinates" at position 0 fails because ["0" must be less than or equal to -66], "coordinates" at position 1 fails because ["1" must be larger than or equal to 23]]]]')
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers hours 6', () => {
-		it('validation should pass because hours follow this format', async () => {
-
-			const testPCObj6 = {
-				hours: {
-					2: [{
-						open: 800,
-						close: 1700
-					}]
-				}
-			}
-
-			const validationObj = await Joi.validate(testPCObj6, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			if (validationObj.error) {
-				throw validationObj.error
-			}
-			const validatedData = validationObj.value
-			validatedData.hours.should.deep.equal({
-				2: [{
-					open: 800,
-					close: 1700
-				}]
-			})
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers readable hours 7', () => {
-		it('validation should fail because tues is not one of the keys (it\'s 1-7)', async () => {
-
-			const testPCObj7 = {
-				hours: {
-					tues: [{
-						open: '800',
-						close: '1700'
-					}]
-				}
-			}
-
-			const validationObj = await Joi.validate(testPCObj7, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			validationObj.error.name.should.equal('ValidationError')
-			validationObj.error.message.should.equal('child "hours" fails because ["tues" is not allowed]')
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers hours 8', () => {
-		it('validation should pass because hours follow this format', async () => {
-
-			const testPCObj8 = {
-				hours: {
-					1: [{
-						open: 800,
-						close: 1600,
-					}]
-				}
-			}
-
-			const validationObj = await Joi.validate(testPCObj8, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			if (validationObj.error) {
-				throw validationObj.error
-			}
-			const validatedData = validationObj.value
-
-			validatedData.hours.should.deep.equal({
-				1: [{
-					open: 800,
-					close: 1600,
-				}]
-			})
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers phone 9', () => {
-		it('validation should fail because phone is in format xxx.xxx.xxx and needs to be in E.164 international format', async () => {
-
-			const testPCObj9 = {
-				phone: '888.444.2222'
-			}
-
-			const validationObj = await Joi.validate(testPCObj9, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			validationObj.error.name.should.equal('ValidationError')
-			validationObj.error.message.should.equal('child "phone" fails because ["phone" needs to be a valid phone number according to E.164 international format]')
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers phone 10', () => {
-		it('validation should pass because phone is in E.164 international format', async () => {
-
-			const testPCObj10 = {
-				phone: '+18884442222'
-			}
-
-			const validationObj = await Joi.validate(testPCObj10, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			if (validationObj.error) {
-				throw validationObj.error
-			}
-			const validatedData = validationObj.value
-			validatedData.phone.should.equal('+18884442222')
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers services 12', () => {
-		it('validation should fail because one of the services is mispelled', async () => {
-
-			const testPCObj12 = {
-				services: {
-					Ulllltrasound: false,
-					parentingClasses: true,
-				}
-			}
-
-			const validationObj = await Joi.validate(testPCObj12, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			validationObj.error.name.should.equal('ValidationError')
-			validationObj.error.message.should.equal('child "services" fails because ["Ulllltrasound" is not allowed]')
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers verified 13', () => {
-		it('validation should fail because each verified field object only has keys date and userId', async () => {
-
-			const testPCObj13 = {
-				verified: {
-					address: {
-						dateVerified: moment()
-					}
-				}
-			}
-
-			const validationObj = await Joi.validate(testPCObj13, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			validationObj.error.name.should.equal('ValidationError')
-			validationObj.error.message.should.equal('child "verified" fails because [child "address" fails because ["dateVerified" is not allowed]]')
-		})
-	})
-
-	/*
-	 * Test the Joi validation for pregnancy centers separately from the API routes
-	 */
-	describe('Test Joi validation for pregnancy centers verified 13', () => {
-		it('validation should pass because the verified field for address has date and userId', async () => {
-
-			const testPCObj13 = {
-				verified: {
-					address: {
-						date: moment().toISOString(),
-						userId: '58e46a8d210140d7e47bf58b'
-					}
-				}
-			}
-
-			const validationObj = await Joi.validate(testPCObj13, pregnancyCenterSchemaJoi, {
-				abortEarly: false
-			})
-			if (validationObj.error) {
-				throw validationObj.error
-			}
-			const validatedData = validationObj.value
-			validatedData.verified.address.userId.should.equal('58e46a8d210140d7e47bf58b')
-		})
-	})
-})
+PregnancyCenterModel
+PregnancyCenterHistoryModel
+pregnancyCenterSchemaJoi
+server
+UserModel
+PersonModel
+
+//
+// chai.use(chaiHttp)
+//
+// // Allows the middleware to think we're already authenticated.
+// function mockAuthenticate() {
+// 	server.request.isAuthenticated = function () {
+// 		return true
+// 	}
+// 	UserModel.findOne({displayName: 'Kate Sills'}, (err, found) => {
+// 		server.request.user =  found
+// 	})
+// }
+//
+// // Allows the middleware to think we are *not* authenticated
+// function mockUnauthenticate () {
+// 	server.request.isAuthenticated = function () {
+// 		return false
+// 	}
+// }
+//
+// function assertError(res, statusCode, error, message=null) {
+// 	res.should.have.status(statusCode)
+// 	res.body.should.have.property('statusCode')
+// 	res.body.should.have.property('error')
+//
+// 	if (message) {
+// 		res.body.should.have.property('message')
+// 		res.body.message.should.equal(message)
+// 	}
+//
+// 	res.body.statusCode.should.equal(statusCode)
+// 	res.body.error.should.equal(error)
+// }
+//
+// function assertUnauthenticatedError(res) {
+// 	assertError(res, 401, 'Unauthorized', 'User is not logged in.')
+// }
+//
+// //Our parent block
+// describe('PregnancyCenters', () => {
+// 	beforeEach( async () => { //Before each test we empty the database
+// 		mockUnauthenticate()
+// 		await PregnancyCenterModel.remove({})
+// 		await UserModel.remove({})
+// 		await PregnancyCenterHistoryModel.remove({})
+// 		await PersonModel.remove({})
+// 		const me = new UserModel({
+// 			displayName: 'Kate Sills'
+// 		})
+// 		await me.save()
+// 		const someoneElse = new UserModel({
+// 			displayName: 'Someone Else'
+// 		})
+// 		return someoneElse.save()
+// 	})
+//
+// 	/*
+// 	 * Test the /GET /api/pregnancy-centers/open-now route w/o authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers/open-now no-auth', () => {
+// 		it('it should return a 401 error because there is no authentication', async () => {
+// 			try {
+// 				await chai.request(server)
+// 					.get('/api/pregnancy-centers/open-now')
+// 					.set('origin', config.corsOriginWhitelist[0])
+// 			} catch (err) {
+// 				assertUnauthenticatedError(err.response)
+// 			}
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /GET /api/pregnancy-centers/open-now route with authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers/open-now ', () => {
+// 		it('it should return one pregnancy center open at 10am on Mondays', async () => {
+//
+// 			const primaryContactPerson = new PersonModel({
+// 				firstName: 'Joanna',
+// 				lastName: 'Smith',
+// 				email: 'email@email.org',
+// 				phone: '+18884442222'
+// 			})
+// 			await primaryContactPerson.save()
+//
+// 			// 1 is Monday
+//
+// 			await PregnancyCenterModel.create({
+// 				'address': {
+// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.7814005,
+// 							42.6722152
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'Birthright of Albany',
+// 				'phone': '+15184382978',
+// 				'primaryContactPerson':  primaryContactPerson,
+// 				'website': 'http://www.birthright.org',
+// 				'services': {},
+// 				'hours': {
+// 					1: [
+// 						{
+// 							open: 800, // 8am
+// 							close: 1500 // 3pm
+// 						}
+// 					] // 1 is Monday
+// 				}
+//
+// 			})
+//
+// 			await PregnancyCenterModel.create({
+// 				'address': {
+// 					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.9241081,
+// 							40.771253
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'The Bridge To Life, Inc.',
+// 				'phone': '+17182743577',
+// 				'email': 'thebridgetolife@verizon.net',
+// 				'website': 'http://www.thebridgetolife.org',
+// 				'services': {},
+// 				'hours': {
+// 					1: [
+// 						{
+// 							open: 1300, // 1pm
+// 							close: 1500 // 3pm
+// 						}
+// 					], // monday
+// 					2: [
+// 						{
+// 							open: 1300, // 1pm
+// 							close: 1500 // 3pm
+// 						}
+// 					],  // tuesday
+// 				}
+// 			})
+//
+// 			mockAuthenticate()
+//
+// 			const res = await chai.request(server)
+// 				.get('/api/pregnancy-centers/open-now?time=1000&day=1')
+// 				.set('origin', config.corsOriginWhitelist[0])
+// 			res.should.have.status(200)
+// 			res.body.should.be.a('array')
+// 			res.body.length.should.be.eql(1)
+// 			res.body[0].prcName.should.equal('Birthright of Albany')
+// 			res.body[0].primaryContactPerson.firstName.should.equal('Joanna')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /GET /api/pregnancy-centers route w/o authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers no-auth', () => {
+// 		it('it should return a 401 error because there is no authentication', async () => {
+// 			try {
+// 				await chai.request(server)
+// 					.get('/api/pregnancy-centers')
+// 					.set('origin', config.corsOriginWhitelist[0])
+// 			} catch (err) {
+// 				assertUnauthenticatedError(err.response)
+// 			}
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /POST /api/pregnancy-centers route w/o authentication
+// 	 */
+// 	describe('/POST /api/pregnancy-centers no-auth', () => {
+// 		it('it should return a 401 error because there is no authentication', async () => {
+// 			const pregnancyCenter = {
+// 				address: {
+// 					line1:'586 Central Ave.\nAlbany, NY 12206',
+// 					location:{
+// 						'type':'Point',
+// 						'coordinates':[-73.7814005, 42.6722152]
+// 					}},
+// 				prcName:'Birthright of Albany',
+// 				phone:'+15184382978',
+// 				website:'http://www.birthright.org',
+// 				services:{},
+// 			}
+//
+// 			try {
+// 				await chai.request(server)
+// 					.post('/api/pregnancy-centers')
+// 					.set('origin', config.corsOriginWhitelist[0])
+// 					.send(pregnancyCenter)
+// 			} catch (err) {
+// 				assertUnauthenticatedError(err.response)
+// 			}
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /GET /api/pregnancy-centers route -- authenticated
+// 	 */
+// 	describe('/GET /api/pregnancy-centers', () => {
+// 		it('it should return an empty array because there are no pregnancy centers yet', async () => {
+// 			mockAuthenticate()
+// 			const res = await chai.request(server)
+// 				.get('/api/pregnancy-centers')
+// 				.set('origin', config.corsOriginWhitelist[0])
+// 			res.should.have.status(200)
+// 			res.body.should.be.a('array')
+// 			res.body.length.should.be.eql(0)
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /POST /api/pregnancy-centers route -- authenticated
+// 	 */
+// 	describe('/POST /api/pregnancy-centers', () => {
+// 		it('it should create a new pregnancy center and return the data', async () => {
+//
+// 			const primaryContactPerson = new PersonModel({
+// 				firstName: 'Joanna',
+// 				lastName: 'Smith',
+// 				email: 'email@email.org',
+// 				phone: '+18884442222'
+// 			})
+// 			await primaryContactPerson.save()
+//
+// 			const pregnancyCenter = {
+// 				address: {
+// 					line1:'586 Central Ave.\nAlbany, NY 12206',
+// 					location:{
+// 						'type':'Point',
+// 						'coordinates':[-73.7814005, 42.6722152]
+// 					}},
+// 				prcName:'Birthright of Albany',
+// 				phone:'+15184382978',
+// 				website:'http://www.birthright.org',
+// 				primaryContactPerson: primaryContactPerson,
+// 				services:{},
+// 			}
+//
+// 			mockAuthenticate()
+// 			const res = await chai.request(server)
+// 				.post('/api/pregnancy-centers')
+// 				.set('origin', config.corsOriginWhitelist[0])
+// 				.send(pregnancyCenter)
+// 			res.should.have.status(201)
+// 			res.body.should.be.a('object')
+// 			res.body.should.have.property('address')
+// 			res.body.should.have.property('prcName')
+// 			res.body.should.have.property('_id')
+// 			res.body.should.have.property('website')
+// 			res.body.should.have.property('phone')
+// 			res.body.should.have.property('primaryContactPerson')
+// 			res.body.primaryContactPerson.firstName.should.equal('Joanna')
+// 			res.body.primaryContactPerson.lastName.should.equal('Smith')
+// 			res.body.primaryContactPerson.email.should.equal('email@email.org')
+// 			res.body.primaryContactPerson.phone.should.equal('+18884442222')
+// 			res.body.address.line1.should.equal('586 Central Ave.\nAlbany, NY 12206')
+// 			res.body.address.location.type.should.equal('Point')
+// 			res.body.address.location.coordinates.should.deep.equal(
+// 				[-73.7814005, 42.6722152])
+// 			res.body.prcName.should.equal('Birthright of Albany')
+// 			res.body.phone.should.equal('+15184382978')
+// 			res.body.website.should.equal('http://www.birthright.org')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the GET /api/pregnancy-centers/near-me' route w/o authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers/near-me no-auth', () => {
+// 		it('it should return a 401 error because there is no authentication', async () => {
+// 			try {
+// 				await chai.request(server)
+// 					.get('/api/pregnancy-centers/near-me')
+// 					.set('origin', config.corsOriginWhitelist[0])
+// 			} catch (err) {
+// 				assertUnauthenticatedError(err.response)
+// 			}
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the GET /api/pregnancy-centers/near-me' route with authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers/near-me', () => {
+// 		it('it should return an array with only the Birthright of Albany in it, not the Bridge to Life', async () => {
+//
+// 			const primaryContactPerson = new PersonModel({
+// 				firstName: 'Joanna',
+// 				lastName: 'Smith',
+// 				email: 'email@email.org',
+// 				phone: '+18884442222'
+// 			})
+// 			await primaryContactPerson.save()
+//
+// 			await PregnancyCenterModel.create({
+// 				'address': {
+// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.7814005,
+// 							42.6722152
+// 						]
+// 					},
+// 				},
+// 				'primaryContactPerson': primaryContactPerson,
+// 				'prcName': 'Birthright of Albany',
+// 				'phone': '+15184382978',
+// 				'website': 'http://www.birthright.org',
+// 				'services': {}
+//
+// 			})
+//
+// 			await PregnancyCenterModel.create({
+// 				'address': {
+// 					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.9241081,
+// 							40.771253
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'The Bridge To Life, Inc.',
+// 				'phone': '+17182743577',
+// 				'email': 'thebridgetolife@verizon.net',
+// 				'website': 'http://www.thebridgetolife.org',
+// 				services:{},
+// 			})
+//
+// 			mockAuthenticate()
+// 			const res = await chai.request(server)
+// 				.get('/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5')
+// 				.set('origin', config.corsOriginWhitelist[0])
+// 			res.should.have.status(200)
+// 			res.body.should.be.a('array')
+// 			res.body.length.should.be.eql(1)
+// 			res.body[0].prcName.should.equal('Birthright of Albany')
+// 			res.body[0].primaryContactPerson.firstName.should.equal('Joanna')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /GET /api/pregnancy-centers/verify route w/o authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers/verify no-auth', () => {
+// 		it('it should return a 401 error because there is no authentication', async () => {
+// 			try {
+// 				await chai.request(server)
+// 					.get('/api/pregnancy-centers/verify')
+// 					.set('origin', config.corsOriginWhitelist[0])
+// 			} catch (err) {
+// 				assertUnauthenticatedError(err.response)
+// 			}
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /GET /api/pregnancy-centers/verify route with authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers/verify', () => {
+// 		it('it should return a single pregnancy center were verified.address is null', async () => {
+//
+// 			const primaryContactPerson = new PersonModel({
+// 				firstName: 'Joanna',
+// 				lastName: 'Smith',
+// 				email: 'email@email.org',
+// 				phone: '+18884442222'
+// 			})
+// 			await primaryContactPerson.save()
+//
+// 			await PregnancyCenterModel.create({
+// 				'address': {
+// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.7814005,
+// 							42.6722152
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'Birthright of Albany',
+// 				'primaryContactPerson': primaryContactPerson,
+// 				'phone': '+15184382978',
+// 				'website': 'http://www.birthright.org',
+// 				services:{},
+//
+// 			})
+//
+// 			const primaryContactPerson2 = new PersonModel({
+// 				firstName: 'Joanna2',
+// 				lastName: 'Smith',
+// 				email: 'email@email.org',
+// 				phone: '+18884442222'
+// 			})
+// 			await primaryContactPerson2.save()
+//
+// 			await PregnancyCenterModel.create({
+// 				'address': {
+// 					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.9241081,
+// 							40.771253
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'The Bridge To Life, Inc.',
+// 				'phone': '+17182743577',
+// 				'primaryContactPerson': primaryContactPerson2,
+// 				'email': 'thebridgetolife@verizon.net',
+// 				'website': 'http://www.thebridgetolife.org',
+// 				'services':{},
+// 				'verified': {
+// 					'address': {
+// 						'date': '2017-04-16T23:33:17.220Z'
+// 					}
+// 				}
+// 			})
+// 			mockAuthenticate()
+//
+// 			const res = await chai.request(server)
+// 				.get('/api/pregnancy-centers/verify')
+// 				.set('origin', config.corsOriginWhitelist[0])
+// 			res.should.have.status(200)
+// 			res.body.should.be.a('object')
+// 			res.body.should.have.property('prcName')
+// 			res.body.prcName.should.equal('Birthright of Albany')
+// 			res.body.primaryContactPerson.firstName.should.equal('Joanna')
+// 			res.body.verified.should.deep.equal({})
+//
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /GET /api/pregnancy-centers/verify route with authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers/verify', () => {
+// 		it('it should return a 404 not found because all pregnancy centers have been verified', async () => {
+//
+// 			await PregnancyCenterModel.create({
+// 				'address': {
+// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.7814005,
+// 							42.6722152
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'Birthright of Albany',
+// 				'phone': '+15184382978',
+// 				'website': 'http://www.birthright.org',
+// 				'services':{},
+// 				'verified': {
+// 					'address': {
+// 						'date' : '2017-04-16T23:33:17.220Z'
+// 					}
+// 				}
+//
+// 			})
+//
+// 			await PregnancyCenterModel.create({
+// 				'address': {
+// 					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.9241081,
+// 							40.771253
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'The Bridge To Life, Inc.',
+// 				'phone': '+17182743577',
+// 				'email': 'thebridgetolife@verizon.net',
+// 				'website': 'http://www.thebridgetolife.org',
+// 				'services': {},
+// 				'verified': {
+// 					'address': {
+// 						'date' : '2017-04-16T23:33:17.220Z'
+// 					}
+// 				}
+// 			})
+//
+// 			mockAuthenticate()
+//
+// 			try {
+// 				await chai.request(server)
+// 					.get('/api/pregnancy-centers/verify')
+// 					.set('origin', config.corsOriginWhitelist[0])
+// 			} catch (err) {
+// 				assertError(err.response, 404, 'Not Found')
+// 			}
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route w/o authentication
+// 	 */
+// 	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId no-auth', () => {
+// 		it('it should return a 401 error because there is no authentication', async () => {
+//
+// 			const pc = new PregnancyCenterModel({
+// 				'address': {
+// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.7814005,
+// 							42.6722152
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'Birthright of Albany',
+// 				'phone': '+15184382978',
+// 				'website': 'http://www.birthright.org',
+// 				'services': {},
+// 				'verified': {
+// 					'address': {
+// 						'date' : '2017-04-16T23:33:17.220Z'
+// 					}
+// 				}
+//
+// 			})
+// 			await pc.save()
+//
+// 			try {
+// 				await chai.request(server)
+// 					.put('/api/pregnancy-centers/'+pc._id)
+// 					.set('origin', config.corsOriginWhitelist[0])
+// 					.send(pc)
+// 			} catch (err) {
+// 				assertUnauthenticatedError(err.response)
+// 			}
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route with authentication
+// 	 */
+// 	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId', () => {
+// 		it('it should return the updated pregnancyCenter record', async () => {
+//
+// 			mockAuthenticate()
+//
+// 			const primaryContactPerson = new PersonModel({
+// 				firstName: 'Joanna',
+// 				lastName: 'Smith',
+// 				email: 'email@email.org',
+// 				phone: '+18884442222'
+// 			})
+// 			await primaryContactPerson.save()
+//
+// 			const oldValues = {
+// 				'address': {
+// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.7814005,
+// 							42.6722152
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'Birthright of Albany',
+// 				'phone': '+15184382978',
+// 				'website': 'http://www.birthright.org',
+// 				'services':{},
+// 				primaryContactPerson: primaryContactPerson,
+// 				'verified': {
+// 					'address': {
+// 						'date' : '2017-04-16T23:33:17.220Z'
+// 					}
+// 				}
+// 			}
+//
+// 			const primaryContactPerson2 = {
+// 				firstName: 'Joanna B',
+// 				lastName: 'Smith',
+// 				email: 'email2@email.org',
+// 				phone: '+18884442222',
+// 				_id: primaryContactPerson._id
+// 			}
+//
+// 			const newValues = {
+// 				'address': {
+// 					'line1': 'New Address',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.7814005,
+// 							42.6722152
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'Birthright of Albany',
+// 				'phone': '+15184382978',
+// 				'website': 'http://www.birthright.org',
+// 				'services':{},
+// 				primaryContactPerson: primaryContactPerson2,
+// 				'verified': {
+// 					'address': {
+// 						'date' : '2017-04-16T23:33:17.220Z'
+// 					}
+// 				}
+// 			}
+//
+// 			const testUser = await UserModel.findOne({ displayName: 'Kate Sills'})
+//
+// 			const oldPCObj = await PregnancyCenterModel.create(oldValues)
+//
+// 			const res = await chai.request(server)
+// 				.put('/api/pregnancy-centers/' + oldPCObj._id)
+// 				.set('origin', config.corsOriginWhitelist[0])
+// 				.send(newValues)
+//
+// 			res.should.have.status(200)
+// 			res.body.should.be.a('object')
+// 			res.body.should.have.property('_id')
+// 			res.body.should.have.property('prcName')
+// 			res.body.should.have.property('primaryContactPerson')
+// 			res.body._id.should.equal(String(oldPCObj._id))
+// 			res.body.prcName.should.equal('Birthright of Albany')
+// 			res.body.should.have.property('verified')
+// 			res.body.should.have.property('updated')
+// 			res.body.updated.should.have.property('address')
+// 			res.body.updated.address.should.have.property('userId')
+// 			res.body.updated.address.userId.should.equal(testUser._id.toString())
+// 			res.body.verified.should.have.property('address')
+//
+// 			// check that the pregnancy center history is created as well.
+// 			const histories = await PregnancyCenterHistoryModel.find({
+// 				pregnancyCenterId: oldPCObj._id
+// 			})
+// 			histories.should.have.length(2) // we want the primary Contact history too.
+// 			for(const pc_history of histories){
+// 				if (pc_history.field == 'primaryContactPerson') {
+// 					pc_history.newValue.firstName.should.equal(primaryContactPerson2.firstName)
+// 				}
+// 			}
+//
+// 			const people = await PersonModel.find({})
+// 			people.should.have.length(1)
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /GET /api/pregnancy-centers/:pregnancyCenterId route w/o authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers/:pregnancyCenterId no-auth', () => {
+// 		it('it should return a 401 error because there is no authentication', async () => {
+//
+// 			const pc = new PregnancyCenterModel({
+// 				'address': {
+// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.7814005,
+// 							42.6722152
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'Birthright of Albany',
+// 				'phone': '+15184382978',
+// 				'website': 'http://www.birthright.org',
+// 				'services':{}
+//
+// 			})
+// 			await pc.save()
+//
+// 			try {
+// 				await chai.request(server)
+// 					.get('/api/pregnancy-centers/'+pc._id)
+// 					.set('origin', config.corsOriginWhitelist[0])
+// 			} catch (err) {
+// 				assertUnauthenticatedError(err.response)
+// 			}
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the /GET /api/pregnancy-centers/:pregnancyCenterId route with authentication
+// 	 */
+// 	describe('/GET /api/pregnancy-centers/:pregnancyCenterId', () => {
+// 		it('it should return a single pregnancy center matching the id', async () => {
+//
+// 			const primaryContactPerson = new PersonModel({
+// 				firstName: 'Joanna',
+// 				lastName: 'Smith',
+// 				email: 'email@email.org',
+// 				phone: '+18884442222'
+// 			})
+// 			await primaryContactPerson.save()
+//
+// 			const pc = new PregnancyCenterModel({
+// 				'address': {
+// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
+// 					'location': {
+// 						'type': 'Point',
+// 						'coordinates': [
+// 							-73.7814005,
+// 							42.6722152
+// 						]
+// 					},
+// 				},
+// 				'prcName': 'Birthright of Albany',
+// 				'primaryContactPerson': primaryContactPerson,
+// 				'phone': '+15184382978',
+// 				'website': 'http://www.birthright.org',
+// 				'services':{}
+//
+// 			})
+//
+// 			await pc.save()
+//
+// 			mockAuthenticate()
+// 			const res = await chai.request(server)
+// 				.get('/api/pregnancy-centers/'+pc._id)
+// 				.set('origin', config.corsOriginWhitelist[0])
+// 			res.should.have.status(200)
+// 			res.body.should.be.a('object')
+// 			res.body.should.have.property('_id')
+// 			res.body.should.have.property('prcName')
+// 			res.body._id.should.equal(String(pc._id))
+// 			res.body.prcName.should.equal('Birthright of Albany')
+// 			res.body.primaryContactPerson.firstName.should.equal('Joanna')
+// 			res.body.verified.should.deep.equal({})
+//
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers address 1', () => {
+// 		it('validation should fail because the address is not an object ', async () => {
+//
+// 			const testPCObj1 = {
+// 				address: 'My address' // should be an object with line1, line2, city, etc.
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj1, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			validationObj.error.name.should.equal('ValidationError')
+// 			validationObj.error.message.should.equal('child "address" fails because ["address" must be an object]')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers address 2', () => {
+// 		it('validation should fail because the location coordinates are reversed ', async () => {
+//
+// 			const testPCObj2 = {
+// 				address: {
+// 					line1: '123 Main Street',
+// 					city: 'Albany',
+// 					state: 'NY',
+// 					location: {
+// 						type: 'Point',
+// 						coordinates: [
+// 							42.6722152,
+// 							-73.7814005 // lat, lng, reversed
+//
+// 						]
+// 					},
+//
+// 				}
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj2, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+//
+// 			validationObj.error.name.should.equal('ValidationError')
+// 			validationObj.error.message.should.equal('child "address" fails because [child "location" fails because [child "coordinates" fails because ["coordinates" at position 0 fails because ["0" must be less than or equal to -66], "coordinates" at position 1 fails because ["1" must be larger than or equal to 23]]]]')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers address 3', () => {
+// 		it('validation should fail because the location coordinates are reversed ', async () => {
+//
+// 			const testPCObj3 = {
+// 				address: {
+// 					line1: '123 Main Street',
+// 					city: 'Albany',
+// 					state: 'NY',
+// 					location: {
+// 						type: 'Point',
+// 						coordinates: [
+// 							42.6722152,
+// 							-73.7814005 // lat, lng, reversed
+//
+// 						]
+// 					},
+//
+// 				}
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj3, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			validationObj.error.name.should.equal('ValidationError')
+// 			validationObj.error.message.should.equal('child "address" fails because [child "location" fails because [child "coordinates" fails because ["coordinates" at position 0 fails because ["0" must be less than or equal to -66], "coordinates" at position 1 fails because ["1" must be larger than or equal to 23]]]]')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers hours 6', () => {
+// 		it('validation should pass because hours follow this format', async () => {
+//
+// 			const testPCObj6 = {
+// 				hours: {
+// 					2: [{
+// 						open: 800,
+// 						close: 1700
+// 					}]
+// 				}
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj6, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			if (validationObj.error) {
+// 				throw validationObj.error
+// 			}
+// 			const validatedData = validationObj.value
+// 			validatedData.hours.should.deep.equal({
+// 				2: [{
+// 					open: 800,
+// 					close: 1700
+// 				}]
+// 			})
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers readable hours 7', () => {
+// 		it('validation should fail because tues is not one of the keys (it\'s 1-7)', async () => {
+//
+// 			const testPCObj7 = {
+// 				hours: {
+// 					tues: [{
+// 						open: '800',
+// 						close: '1700'
+// 					}]
+// 				}
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj7, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			validationObj.error.name.should.equal('ValidationError')
+// 			validationObj.error.message.should.equal('child "hours" fails because ["tues" is not allowed]')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers hours 8', () => {
+// 		it('validation should pass because hours follow this format', async () => {
+//
+// 			const testPCObj8 = {
+// 				hours: {
+// 					1: [{
+// 						open: 800,
+// 						close: 1600,
+// 					}]
+// 				}
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj8, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			if (validationObj.error) {
+// 				throw validationObj.error
+// 			}
+// 			const validatedData = validationObj.value
+//
+// 			validatedData.hours.should.deep.equal({
+// 				1: [{
+// 					open: 800,
+// 					close: 1600,
+// 				}]
+// 			})
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers phone 9', () => {
+// 		it('validation should fail because phone is in format xxx.xxx.xxx and needs to be in E.164 international format', async () => {
+//
+// 			const testPCObj9 = {
+// 				phone: '888.444.2222'
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj9, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			validationObj.error.name.should.equal('ValidationError')
+// 			validationObj.error.message.should.equal('child "phone" fails because ["phone" needs to be a valid phone number according to E.164 international format]')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers phone 10', () => {
+// 		it('validation should pass because phone is in E.164 international format', async () => {
+//
+// 			const testPCObj10 = {
+// 				phone: '+18884442222'
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj10, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			if (validationObj.error) {
+// 				throw validationObj.error
+// 			}
+// 			const validatedData = validationObj.value
+// 			validatedData.phone.should.equal('+18884442222')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers services 12', () => {
+// 		it('validation should fail because one of the services is mispelled', async () => {
+//
+// 			const testPCObj12 = {
+// 				services: {
+// 					Ulllltrasound: false,
+// 					parentingClasses: true,
+// 				}
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj12, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			validationObj.error.name.should.equal('ValidationError')
+// 			validationObj.error.message.should.equal('child "services" fails because ["Ulllltrasound" is not allowed]')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers verified 13', () => {
+// 		it('validation should fail because each verified field object only has keys date and userId', async () => {
+//
+// 			const testPCObj13 = {
+// 				verified: {
+// 					address: {
+// 						dateVerified: moment()
+// 					}
+// 				}
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj13, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			validationObj.error.name.should.equal('ValidationError')
+// 			validationObj.error.message.should.equal('child "verified" fails because [child "address" fails because ["dateVerified" is not allowed]]')
+// 		})
+// 	})
+//
+// 	/*
+// 	 * Test the Joi validation for pregnancy centers separately from the API routes
+// 	 */
+// 	describe('Test Joi validation for pregnancy centers verified 13', () => {
+// 		it('validation should pass because the verified field for address has date and userId', async () => {
+//
+// 			const testPCObj13 = {
+// 				verified: {
+// 					address: {
+// 						date: moment().toISOString(),
+// 						userId: '58e46a8d210140d7e47bf58b'
+// 					}
+// 				}
+// 			}
+//
+// 			const validationObj = await Joi.validate(testPCObj13, pregnancyCenterSchemaJoi, {
+// 				abortEarly: false
+// 			})
+// 			if (validationObj.error) {
+// 				throw validationObj.error
+// 			}
+// 			const validatedData = validationObj.value
+// 			validatedData.verified.address.userId.should.equal('58e46a8d210140d7e47bf58b')
+// 		})
+// 	})
+// })

--- a/server/data-import/test/test.js
+++ b/server/data-import/test/test.js
@@ -1,17 +1,17 @@
 'use strict'
 
-// const moment = require('moment')
-//
-// //Require the dev-dependencies
-// const chai = require('chai')
-// const chaiHttp = require('chai-http')
-// const config = require('config')
-// // eslint-disable-next-line no-unused-vars
-// const should = chai.should()
-// const Joi = require('joi')
-// const Log = require('log')
-// const mongoose = require('mongoose')
-// mongoose.Promise = require('bluebird')
+const moment = require('moment')
+
+//Require the dev-dependencies
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const config = require('config')
+// eslint-disable-next-line no-unused-vars
+const should = chai.should()
+const Joi = require('joi')
+const Log = require('log')
+const mongoose = require('mongoose')
+mongoose.Promise = require('bluebird')
 
 const PregnancyCenterHistoryModel = require('../../pregnancy-center-history/schema/mongoose-schema')
 const PregnancyCenterModel = require('../../pregnancy-centers/schema/mongoose-schema')
@@ -19,979 +19,980 @@ const pregnancyCenterSchemaJoi = require('../../pregnancy-centers/schema/joi-sch
 const server = require('../../server')
 const UserModel = require('../../users/schema/mongoose-schema')
 
-PregnancyCenterHistoryModel
-PregnancyCenterModel
-pregnancyCenterSchemaJoi
-server
-UserModel
 
-// chai.use(chaiHttp)
-// const log = new Log('info')
-//
-// // Allows the middleware to think we're already authenticated.
-// function mockAuthenticate() {
-// 	server.request.isAuthenticated = function () {
-// 		return true
-// 	}
-// 	UserModel.findOne({displayName: 'Kate Sills'}, (err, found) => {
-// 		server.request.user =  found
-// 	})
-// }
-//
-// // Allows the middleware to think we are *not* authenticated
-// function mockUnauthenticate () {
-// 	server.request.isAuthenticated = function () {
-// 		return false
-// 	}
-// }
-//
-// function assertError(res, statusCode, error, message=null) {
-// 	res.should.have.status(statusCode)
-// 	res.body.should.have.property('statusCode')
-// 	res.body.should.have.property('error')
-//
-// 	if (message) {
-// 		res.body.should.have.property('message')
-// 		res.body.message.should.equal(message)
-// 	}
-//
-// 	res.body.statusCode.should.equal(statusCode)
-// 	res.body.error.should.equal(error)
-// }
-//
-// function assertUnauthenticatedError(res) {
-// 	assertError(res, 401, 'Unauthorized', 'User is not logged in.')
-// }
-//
-// //Our parent block
-// describe('PregnancyCenters', () => {
-// 	beforeEach( async () => { //Before each test we empty the database
-// 		mockUnauthenticate()
-// 		await PregnancyCenterModel.remove({})
-// 		await UserModel.remove({})
-// 		const me = new UserModel({
-// 			displayName: 'Kate Sills'
-// 		})
-// 		await me.save()
-// 		const someoneElse = new UserModel({
-// 			displayName: 'Someone Else'
-// 		})
-// 		return someoneElse.save()
-// 	})
-//
-// 	/*
-// 	 * Test the /GET /api/pregnancy-centers/open-now route w/o authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers/open-now no-auth', () => {
-// 		it('it should return a 401 error because there is no authentication', async () => {
-// 			try {
-// 				await chai.request(server)
-// 					.get('/api/pregnancy-centers/open-now')
-// 					.set('origin', config.corsOriginWhitelist[0])
-// 			} catch (err) {
-// 				assertUnauthenticatedError(err.response)
-// 			}
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /GET /api/pregnancy-centers/open-now route with authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers/open-now ', () => {
-// 		it('it should return one pregnancy center open at 10am on Mondays', async () => {
-//
-// 			// 1 is Monday
-//
-// 			await PregnancyCenterModel.create({
-// 				'address': {
-// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.7814005,
-// 							42.6722152
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'Birthright of Albany',
-// 				'phone': '+15184382978',
-// 				'website': 'http://www.birthright.org',
-// 				'services': {},
-// 				'hours': {
-// 					1: [
-// 						{
-// 							open: 800, // 8am
-// 							close: 1500 // 3pm
-// 						}
-// 					] // 1 is Monday
-// 				}
-//
-// 			})
-//
-// 			await PregnancyCenterModel.create({
-// 				'address': {
-// 					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.9241081,
-// 							40.771253
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'The Bridge To Life, Inc.',
-// 				'phone': '+17182743577',
-// 				'email': 'thebridgetolife@verizon.net',
-// 				'website': 'http://www.thebridgetolife.org',
-// 				'services': {},
-// 				'hours': {
-// 					1: [
-// 						{
-// 							open: 1300, // 1pm
-// 							close: 1500 // 3pm
-// 						}
-// 					], // monday
-// 					2: [
-// 						{
-// 							open: 1300, // 1pm
-// 							close: 1500 // 3pm
-// 						}
-// 					],  // tuesday
-// 				}
-// 			})
-//
-// 			mockAuthenticate()
-//
-// 			const res = await chai.request(server)
-// 				.get('/api/pregnancy-centers/open-now?time=1000&day=1')
-// 				.set('origin', config.corsOriginWhitelist[0])
-// 			res.should.have.status(200)
-// 			res.body.should.be.a('array')
-// 			res.body.length.should.be.eql(1)
-// 			res.body[0].prcName.should.equal('Birthright of Albany')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /GET /api/pregnancy-centers route w/o authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers no-auth', () => {
-// 		it('it should return a 401 error because there is no authentication', async () => {
-// 			try {
-// 				await chai.request(server)
-// 					.get('/api/pregnancy-centers')
-// 					.set('origin', config.corsOriginWhitelist[0])
-// 			} catch (err) {
-// 				assertUnauthenticatedError(err.response)
-// 			}
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /POST /api/pregnancy-centers route w/o authentication
-// 	 */
-// 	describe('/POST /api/pregnancy-centers no-auth', () => {
-// 		it('it should return a 401 error because there is no authentication', async () => {
-// 			const pregnancyCenter = {
-// 				address: {
-// 					line1:'586 Central Ave.\nAlbany, NY 12206',
-// 					location:{
-// 						'type':'Point',
-// 						'coordinates':[-73.7814005, 42.6722152]
-// 					}},
-// 				prcName:'Birthright of Albany',
-// 				phone:'+15184382978',
-// 				website:'http://www.birthright.org',
-// 				services:{},
-// 			}
-//
-// 			try {
-// 				await chai.request(server)
-// 					.post('/api/pregnancy-centers')
-// 					.set('origin', config.corsOriginWhitelist[0])
-// 					.send(pregnancyCenter)
-// 			} catch (err) {
-// 				assertUnauthenticatedError(err.response)
-// 			}
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /GET /api/pregnancy-centers route -- authenticated
-// 	 */
-// 	describe('/GET /api/pregnancy-centers', () => {
-// 		it('it should return an empty array because there are no pregnancy centers yet', async () => {
-// 			mockAuthenticate()
-// 			const res = await chai.request(server)
-// 				.get('/api/pregnancy-centers')
-// 				.set('origin', config.corsOriginWhitelist[0])
-// 			res.should.have.status(200)
-// 			res.body.should.be.a('array')
-// 			res.body.length.should.be.eql(0)
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /POST /api/pregnancy-centers route -- authenticated
-// 	 */
-// 	describe('/POST /api/pregnancy-centers', () => {
-// 		it('it should create a new pregnancy center and return the data', async () => {
-// 			const pregnancyCenter = {
-// 				address: {
-// 					line1:'586 Central Ave.\nAlbany, NY 12206',
-// 					location:{
-// 						'type':'Point',
-// 						'coordinates':[-73.7814005, 42.6722152]
-// 					}},
-// 				prcName:'Birthright of Albany',
-// 				phone:'+15184382978',
-// 				website:'http://www.birthright.org',
-// 				// primaryContactUser: {
-// 				// 	firstName: 'Joanna',
-// 				// 	lastName: 'Smith',
-// 				// 	email: 'email@email.org',
-// 				// 	phone: '+18884442222'
-// 				// },
-// 				services:{},
-// 			}
-// 			mockAuthenticate()
-// 			const res = await chai.request(server)
-// 				.post('/api/pregnancy-centers')
-// 				.set('origin', config.corsOriginWhitelist[0])
-// 				.send(pregnancyCenter)
-// 			res.should.have.status(201)
-// 			res.body.should.be.a('object')
-// 			res.body.should.have.property('address')
-// 			res.body.should.have.property('prcName')
-// 			res.body.should.have.property('_id')
-// 			res.body.should.have.property('website')
-// 			res.body.should.have.property('phone')
-// 			// res.body.should.have.property('primaryContactUser')
-// 			// res.body.primaryContactUser.firstName.should.equal('Joanna')
-// 			// res.body.primaryContactUser.lastName.should.equal('Smith')
-// 			// res.body.primaryContactUser.email.should.equal('email@email.org')
-// 			// res.body.primaryContactUser.phone.should.equal('+18884442222')
-// 			res.body.address.line1.should.equal('586 Central Ave.\nAlbany, NY 12206')
-// 			res.body.address.location.type.should.equal('Point')
-// 			res.body.address.location.coordinates.should.deep.equal(
-// 				[-73.7814005, 42.6722152])
-// 			res.body.prcName.should.equal('Birthright of Albany')
-// 			res.body.phone.should.equal('+15184382978')
-// 			res.body.website.should.equal('http://www.birthright.org')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the GET /api/pregnancy-centers/near-me' route w/o authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers/near-me no-auth', () => {
-// 		it('it should return a 401 error because there is no authentication', async () => {
-// 			try {
-// 				await chai.request(server)
-// 					.get('/api/pregnancy-centers/near-me')
-// 					.set('origin', config.corsOriginWhitelist[0])
-// 			} catch (err) {
-// 				assertUnauthenticatedError(err.response)
-// 			}
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the GET /api/pregnancy-centers/near-me' route with authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers/near-me', () => {
-// 		it('it should return an array with only the Birthright of Albany in it, not the Bridge to Life', async () => {
-//
-// 			await PregnancyCenterModel.create({
-// 				'address': {
-// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.7814005,
-// 							42.6722152
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'Birthright of Albany',
-// 				'phone': '+15184382978',
-// 				'website': 'http://www.birthright.org',
-// 				'services': {}
-//
-// 			})
-//
-// 			await PregnancyCenterModel.create({
-// 				'address': {
-// 					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.9241081,
-// 							40.771253
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'The Bridge To Life, Inc.',
-// 				'phone': '+17182743577',
-// 				'email': 'thebridgetolife@verizon.net',
-// 				'website': 'http://www.thebridgetolife.org',
-// 				services:{},
-// 			})
-//
-// 			mockAuthenticate()
-// 			const res = await chai.request(server)
-// 				.get('/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5')
-// 				.set('origin', config.corsOriginWhitelist[0])
-// 			res.should.have.status(200)
-// 			res.body.should.be.a('array')
-// 			res.body.length.should.be.eql(1)
-// 			res.body[0].prcName.should.equal('Birthright of Albany')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /GET /api/pregnancy-centers/verify route w/o authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers/verify no-auth', () => {
-// 		it('it should return a 401 error because there is no authentication', async () => {
-// 			try {
-// 				await chai.request(server)
-// 					.get('/api/pregnancy-centers/verify')
-// 					.set('origin', config.corsOriginWhitelist[0])
-// 			} catch (err) {
-// 				assertUnauthenticatedError(err.response)
-// 			}
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /GET /api/pregnancy-centers/verify route with authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers/verify', () => {
-// 		it('it should return a single pregnancy center were verified.address is null', async () => {
-//
-// 			await PregnancyCenterModel.create({
-// 				'address': {
-// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.7814005,
-// 							42.6722152
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'Birthright of Albany',
-// 				'phone': '+15184382978',
-// 				'website': 'http://www.birthright.org',
-// 				services:{},
-//
-// 			})
-//
-// 			await PregnancyCenterModel.create({
-// 				'address': {
-// 					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.9241081,
-// 							40.771253
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'The Bridge To Life, Inc.',
-// 				'phone': '+17182743577',
-// 				'email': 'thebridgetolife@verizon.net',
-// 				'website': 'http://www.thebridgetolife.org',
-// 				'services':{},
-// 				'verified': {
-// 					'address': {
-// 						'date': '2017-04-16T23:33:17.220Z'
-// 					}
-// 				}
-// 			})
-// 			mockAuthenticate()
-//
-// 			const res = await chai.request(server)
-// 				.get('/api/pregnancy-centers/verify')
-// 				.set('origin', config.corsOriginWhitelist[0])
-// 			res.should.have.status(200)
-// 			res.body.should.be.a('object')
-// 			res.body.should.have.property('prcName')
-// 			res.body.prcName.should.equal('Birthright of Albany')
-// 			res.body.verified.should.deep.equal({})
-//
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /GET /api/pregnancy-centers/verify route with authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers/verify', () => {
-// 		it('it should return a 404 not found because all pregnancy centers have been verified', async () => {
-//
-// 			await PregnancyCenterModel.create({
-// 				'address': {
-// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.7814005,
-// 							42.6722152
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'Birthright of Albany',
-// 				'phone': '+15184382978',
-// 				'website': 'http://www.birthright.org',
-// 				'services':{},
-// 				'verified': {
-// 					'address': {
-// 						'date' : '2017-04-16T23:33:17.220Z'
-// 					}
-// 				}
-//
-// 			})
-//
-// 			await PregnancyCenterModel.create({
-// 				'address': {
-// 					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.9241081,
-// 							40.771253
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'The Bridge To Life, Inc.',
-// 				'phone': '+17182743577',
-// 				'email': 'thebridgetolife@verizon.net',
-// 				'website': 'http://www.thebridgetolife.org',
-// 				'services': {},
-// 				'verified': {
-// 					'address': {
-// 						'date' : '2017-04-16T23:33:17.220Z'
-// 					}
-// 				}
-// 			})
-//
-// 			mockAuthenticate()
-//
-// 			try {
-// 				await chai.request(server)
-// 					.get('/api/pregnancy-centers/verify')
-// 					.set('origin', config.corsOriginWhitelist[0])
-// 			} catch (err) {
-// 				assertError(err.response, 404, 'Not Found')
-// 			}
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route w/o authentication
-// 	 */
-// 	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId no-auth', () => {
-// 		it('it should return a 401 error because there is no authentication', async () => {
-//
-// 			const pc = new PregnancyCenterModel({
-// 				'address': {
-// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.7814005,
-// 							42.6722152
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'Birthright of Albany',
-// 				'phone': '+15184382978',
-// 				'website': 'http://www.birthright.org',
-// 				'services': {},
-// 				'verified': {
-// 					'address': {
-// 						'date' : '2017-04-16T23:33:17.220Z'
-// 					}
-// 				}
-//
-// 			})
-// 			await pc.save()
-//
-// 			try {
-// 				await chai.request(server)
-// 					.put('/api/pregnancy-centers/'+pc._id)
-// 					.set('origin', config.corsOriginWhitelist[0])
-// 					.send(pc)
-// 			} catch (err) {
-// 				assertUnauthenticatedError(err.response)
-// 			}
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route with authentication
-// 	 */
-// 	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId', () => {
-// 		it('it should return the updated pregnancyCenter record', async () => {
-//
-// 			const oldValues = {
-// 				'address': {
-// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.7814005,
-// 							42.6722152
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'Birthright of Albany',
-// 				'phone': '+15184382978',
-// 				'website': 'http://www.birthright.org',
-// 				'services':{},
-// 				// primaryContactUser: {
-// 				// 	firstName: 'Joanna',
-// 				// 	lastName: 'Smith',
-// 				// 	email: 'email@email.org',
-// 				// 	phone: '+18884442222'
-// 				// },
-// 				'verified': {
-// 					'address': {
-// 						'date' : '2017-04-16T23:33:17.220Z'
-// 					}
-// 				}
-// 			}
-//
-// 			const newValues = {
-// 				'address': {
-// 					'line1': 'New Address',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.7814005,
-// 							42.6722152
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'Birthright of Albany',
-// 				'phone': '+15184382978',
-// 				'website': 'http://www.birthright.org',
-// 				'services':{},
-// 				// primaryContactUser: {
-// 				// 	firstName: 'Joanna B',
-// 				// 	lastName: 'Smith',
-// 				// 	email: 'email2@email.org',
-// 				// 	phone: '+18884442222'
-// 				// },
-// 				'verified': {
-// 					'address': {
-// 						'date' : '2017-04-16T23:33:17.220Z'
-// 					}
-// 				}
-// 			}
-//
-// 			const testUser = await UserModel.findOne({ displayName: 'Kate Sills'})
-//
-// 			const oldPCObj = await PregnancyCenterModel.create(oldValues)
-//
-// 			mockAuthenticate()
-//
-// 			const res = await chai.request(server)
-// 				.put('/api/pregnancy-centers/' + oldPCObj._id)
-// 				.set('origin', config.corsOriginWhitelist[0])
-// 				.send(newValues)
-//
-// 			res.should.have.status(200)
-// 			log.info(res.body)
-// 			res.body.should.be.a('object')
-// 			res.body.should.have.property('_id')
-// 			res.body.should.have.property('prcName')
-// 			// res.body.should.have.property('primaryContactUser')
-// 			res.body._id.should.equal(String(oldPCObj._id))
-// 			res.body.prcName.should.equal('Birthright of Albany')
-// 			res.body.should.have.property('verified')
-// 			res.body.should.have.property('updated')
-// 			res.body.updated.should.have.property('address')
-// 			res.body.updated.address.should.have.property('userId')
-// 			res.body.updated.address.userId.should.equal(testUser._id.toString())
-// 			res.body.verified.should.have.property('address')
-//
-// 			// check that the pregnancy center history is created as well.
-// 			const newPCObj = await PregnancyCenterHistoryModel.find({
-// 				pregnancyCenterId: oldPCObj._id
-// 			})
-// 			log.info(newPCObj)
-// 			newPCObj.should.have.length(1)
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /GET /api/pregnancy-centers/:pregnancyCenterId route w/o authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers/:pregnancyCenterId no-auth', () => {
-// 		it('it should return a 401 error because there is no authentication', async () => {
-//
-// 			const pc = new PregnancyCenterModel({
-// 				'address': {
-// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.7814005,
-// 							42.6722152
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'Birthright of Albany',
-// 				'phone': '+15184382978',
-// 				'website': 'http://www.birthright.org',
-// 				'services':{}
-//
-// 			})
-// 			await pc.save()
-//
-// 			try {
-// 				await chai.request(server)
-// 					.get('/api/pregnancy-centers/'+pc._id)
-// 					.set('origin', config.corsOriginWhitelist[0])
-// 			} catch (err) {
-// 				assertUnauthenticatedError(err.response)
-// 			}
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the /GET /api/pregnancy-centers/:pregnancyCenterId route with authentication
-// 	 */
-// 	describe('/GET /api/pregnancy-centers/:pregnancyCenterId', () => {
-// 		it('it should return a single pregnancy center matching the id', async () => {
-//
-// 			const pc = new PregnancyCenterModel({
-// 				'address': {
-// 					'line1': '586 Central Ave.\nAlbany, NY 12206',
-// 					'location': {
-// 						'type': 'Point',
-// 						'coordinates': [
-// 							-73.7814005,
-// 							42.6722152
-// 						]
-// 					},
-// 				},
-// 				'prcName': 'Birthright of Albany',
-// 				'phone': '+15184382978',
-// 				'website': 'http://www.birthright.org',
-// 				'services':{}
-//
-// 			})
-//
-// 			await pc.save()
-//
-// 			mockAuthenticate()
-// 			const res = await chai.request(server)
-// 				.get('/api/pregnancy-centers/'+pc._id)
-// 				.set('origin', config.corsOriginWhitelist[0])
-// 			res.should.have.status(200)
-// 			res.body.should.be.a('object')
-// 			res.body.should.have.property('_id')
-// 			res.body.should.have.property('prcName')
-// 			res.body._id.should.equal(String(pc._id))
-// 			res.body.prcName.should.equal('Birthright of Albany')
-// 			res.body.verified.should.deep.equal({})
-//
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers address 1', () => {
-// 		it('validation should fail because the address is not an object ', async () => {
-//
-// 			const testPCObj1 = {
-// 				address: 'My address' // should be an object with line1, line2, city, etc.
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj1, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			validationObj.error.name.should.equal('ValidationError')
-// 			validationObj.error.message.should.equal('child "address" fails because ["address" must be an object]')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers address 2', () => {
-// 		it('validation should fail because the location coordinates are reversed ', async () => {
-//
-// 			const testPCObj2 = {
-// 				address: {
-// 					line1: '123 Main Street',
-// 					city: 'Albany',
-// 					state: 'NY',
-// 					location: {
-// 						type: 'Point',
-// 						coordinates: [
-// 							42.6722152,
-// 							-73.7814005 // lat, lng, reversed
-//
-// 						]
-// 					},
-//
-// 				}
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj2, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-//
-// 			validationObj.error.name.should.equal('ValidationError')
-// 			validationObj.error.message.should.equal('child "address" fails because [child "location" fails because [child "coordinates" fails because ["coordinates" at position 0 fails because ["0" must be less than or equal to -66], "coordinates" at position 1 fails because ["1" must be larger than or equal to 23]]]]')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers address 3', () => {
-// 		it('validation should fail because the location coordinates are reversed ', async () => {
-//
-// 			const testPCObj3 = {
-// 				address: {
-// 					line1: '123 Main Street',
-// 					city: 'Albany',
-// 					state: 'NY',
-// 					location: {
-// 						type: 'Point',
-// 						coordinates: [
-// 							42.6722152,
-// 							-73.7814005 // lat, lng, reversed
-//
-// 						]
-// 					},
-//
-// 				}
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj3, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			validationObj.error.name.should.equal('ValidationError')
-// 			validationObj.error.message.should.equal('child "address" fails because [child "location" fails because [child "coordinates" fails because ["coordinates" at position 0 fails because ["0" must be less than or equal to -66], "coordinates" at position 1 fails because ["1" must be larger than or equal to 23]]]]')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers dateCreated 4', () => {
-// 		it('validation should fail because the dateCreated provided is not a date ', async () => {
-//
-// 			const testPCObj4 = {
-// 				dateCreated: '3/3/2017'
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj4, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			validationObj.error.name.should.equal('ValidationError')
-// 			validationObj.error.message.should.equal('child "dateCreated" fails because ["dateCreated" must be a valid ISO 8601 date]')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers hours 6', () => {
-// 		it('validation should pass because hours follow this format', async () => {
-//
-// 			const testPCObj6 = {
-// 				hours: {
-// 					2: [{
-// 						open: 800,
-// 						close: 1700
-// 					}]
-// 				}
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj6, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			if (validationObj.error) {
-// 				throw validationObj.error
-// 			}
-// 			const validatedData = validationObj.value
-// 			validatedData.hours.should.deep.equal({
-// 				2: [{
-// 					open: 800,
-// 					close: 1700
-// 				}]
-// 			})
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers readable hours 7', () => {
-// 		it('validation should fail because tues is not one of the keys (it\'s 1-7)', async () => {
-//
-// 			const testPCObj7 = {
-// 				hours: {
-// 					tues: [{
-// 						open: '800',
-// 						close: '1700'
-// 					}]
-// 				}
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj7, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			validationObj.error.name.should.equal('ValidationError')
-// 			validationObj.error.message.should.equal('child "hours" fails because ["tues" is not allowed]')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers hours 8', () => {
-// 		it('validation should pass because hours follow this format', async () => {
-//
-// 			const testPCObj8 = {
-// 				hours: {
-// 					1: [{
-// 						open: 800,
-// 						close: 1600,
-// 					}]
-// 				}
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj8, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			if (validationObj.error) {
-// 				throw validationObj.error
-// 			}
-// 			const validatedData = validationObj.value
-//
-// 			validatedData.hours.should.deep.equal({
-// 				1: [{
-// 					open: 800,
-// 					close: 1600,
-// 				}]
-// 			})
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers phone 9', () => {
-// 		it('validation should fail because phone is in format xxx.xxx.xxx and needs to be in E.164 international format', async () => {
-//
-// 			const testPCObj9 = {
-// 				phone: '888.444.2222'
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj9, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			validationObj.error.name.should.equal('ValidationError')
-// 			validationObj.error.message.should.equal('child "phone" fails because ["phone" needs to be a valid phone number according to E.164 international format]')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers phone 10', () => {
-// 		it('validation should pass because phone is in E.164 international format', async () => {
-//
-// 			const testPCObj10 = {
-// 				phone: '+18884442222'
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj10, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			if (validationObj.error) {
-// 				throw validationObj.error
-// 			}
-// 			const validatedData = validationObj.value
-// 			validatedData.phone.should.equal('+18884442222')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers services 12', () => {
-// 		it('validation should fail because one of the services is mispelled', async () => {
-//
-// 			const testPCObj12 = {
-// 				services: {
-// 					Ulllltrasound: false,
-// 					parentingClasses: true,
-// 				}
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj12, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			validationObj.error.name.should.equal('ValidationError')
-// 			validationObj.error.message.should.equal('child "services" fails because ["Ulllltrasound" is not allowed]')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers verified 13', () => {
-// 		it('validation should fail because each verified field object only has keys date and userId', async () => {
-//
-// 			const testPCObj13 = {
-// 				verified: {
-// 					address: {
-// 						dateVerified: moment()
-// 					}
-// 				}
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj13, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			validationObj.error.name.should.equal('ValidationError')
-// 			validationObj.error.message.should.equal('child "verified" fails because [child "address" fails because ["dateVerified" is not allowed]]')
-// 		})
-// 	})
-//
-// 	/*
-// 	 * Test the Joi validation for pregnancy centers separately from the API routes
-// 	 */
-// 	describe('Test Joi validation for pregnancy centers verified 13', () => {
-// 		it('validation should pass because the verified field for address has date and userId', async () => {
-//
-// 			const testPCObj13 = {
-// 				verified: {
-// 					address: {
-// 						date: moment().toISOString(),
-// 						userId: '58e46a8d210140d7e47bf58b'
-// 					}
-// 				}
-// 			}
-//
-// 			const validationObj = await Joi.validate(testPCObj13, pregnancyCenterSchemaJoi, {
-// 				abortEarly: false
-// 			})
-// 			if (validationObj.error) {
-// 				throw validationObj.error
-// 			}
-// 			const validatedData = validationObj.value
-// 			validatedData.verified.address.userId.should.equal('58e46a8d210140d7e47bf58b')
-// 		})
-// 	})
-// })
+
+chai.use(chaiHttp)
+const log = new Log('info')
+
+// Allows the middleware to think we're already authenticated.
+function mockAuthenticate() {
+	server.request.isAuthenticated = function () {
+		return true
+	}
+	UserModel.findOne({displayName: 'Kate Sills'}, (err, found) => {
+		server.request.user =  found
+	})
+}
+
+// Allows the middleware to think we are *not* authenticated
+function mockUnauthenticate () {
+	server.request.isAuthenticated = function () {
+		return false
+	}
+}
+
+function assertError(res, statusCode, error, message=null) {
+	res.should.have.status(statusCode)
+	res.body.should.have.property('statusCode')
+	res.body.should.have.property('error')
+
+	if (message) {
+		res.body.should.have.property('message')
+		res.body.message.should.equal(message)
+	}
+
+	res.body.statusCode.should.equal(statusCode)
+	res.body.error.should.equal(error)
+}
+
+function assertUnauthenticatedError(res) {
+	assertError(res, 401, 'Unauthorized', 'User is not logged in.')
+}
+
+//Our parent block
+describe('PregnancyCenters', () => {
+	beforeEach( async () => { //Before each test we empty the database
+		mockUnauthenticate()
+		await PregnancyCenterModel.remove({})
+		await UserModel.remove({})
+		const me = new UserModel({
+			displayName: 'Kate Sills'
+		})
+		await me.save()
+		const someoneElse = new UserModel({
+			displayName: 'Someone Else'
+		})
+		return someoneElse.save()
+	})
+
+	/*
+	 * Test the /GET /api/pregnancy-centers/open-now route w/o authentication
+	 */
+	describe('/GET /api/pregnancy-centers/open-now no-auth', () => {
+		it('it should return a 401 error because there is no authentication', async () => {
+			try {
+				await chai.request(server)
+					.get('/api/pregnancy-centers/open-now')
+					.set('origin', config.corsOriginWhitelist[0])
+			} catch (err) {
+				assertUnauthenticatedError(err.response)
+			}
+		})
+	})
+
+	/*
+	 * Test the /GET /api/pregnancy-centers/open-now route with authentication
+	 */
+	describe('/GET /api/pregnancy-centers/open-now ', () => {
+		it('it should return one pregnancy center open at 10am on Mondays', async () => {
+
+			// 1 is Monday
+
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services': {},
+				'hours': {
+					1: [
+						{
+							open: 800, // 8am
+							close: 1500 // 3pm
+						}
+					] // 1 is Monday
+				}
+
+			})
+
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.9241081,
+							40.771253
+						]
+					},
+				},
+				'prcName': 'The Bridge To Life, Inc.',
+				'phone': '+17182743577',
+				'email': 'thebridgetolife@verizon.net',
+				'website': 'http://www.thebridgetolife.org',
+				'services': {},
+				'hours': {
+					1: [
+						{
+							open: 1300, // 1pm
+							close: 1500 // 3pm
+						}
+					], // monday
+					2: [
+						{
+							open: 1300, // 1pm
+							close: 1500 // 3pm
+						}
+					],  // tuesday
+				}
+			})
+
+			mockAuthenticate()
+
+			const res = await chai.request(server)
+				.get('/api/pregnancy-centers/open-now?time=1000&day=1')
+				.set('origin', config.corsOriginWhitelist[0])
+			res.should.have.status(200)
+			res.body.should.be.a('array')
+			res.body.length.should.be.eql(1)
+			res.body[0].prcName.should.equal('Birthright of Albany')
+		})
+	})
+
+	/*
+	 * Test the /GET /api/pregnancy-centers route w/o authentication
+	 */
+	describe('/GET /api/pregnancy-centers no-auth', () => {
+		it('it should return a 401 error because there is no authentication', async () => {
+			try {
+				await chai.request(server)
+					.get('/api/pregnancy-centers')
+					.set('origin', config.corsOriginWhitelist[0])
+			} catch (err) {
+				assertUnauthenticatedError(err.response)
+			}
+		})
+	})
+
+	/*
+	 * Test the /POST /api/pregnancy-centers route w/o authentication
+	 */
+	describe('/POST /api/pregnancy-centers no-auth', () => {
+		it('it should return a 401 error because there is no authentication', async () => {
+			const pregnancyCenter = {
+				address: {
+					line1:'586 Central Ave.\nAlbany, NY 12206',
+					location:{
+						'type':'Point',
+						'coordinates':[-73.7814005, 42.6722152]
+					}},
+				prcName:'Birthright of Albany',
+				phone:'+15184382978',
+				website:'http://www.birthright.org',
+				services:{},
+			}
+
+			try {
+				await chai.request(server)
+					.post('/api/pregnancy-centers')
+					.set('origin', config.corsOriginWhitelist[0])
+					.send(pregnancyCenter)
+			} catch (err) {
+				assertUnauthenticatedError(err.response)
+			}
+		})
+	})
+
+	/*
+	 * Test the /GET /api/pregnancy-centers route -- authenticated
+	 */
+	describe('/GET /api/pregnancy-centers', () => {
+		it('it should return an empty array because there are no pregnancy centers yet', async () => {
+			mockAuthenticate()
+			const res = await chai.request(server)
+				.get('/api/pregnancy-centers')
+				.set('origin', config.corsOriginWhitelist[0])
+			res.should.have.status(200)
+			res.body.should.be.a('array')
+			res.body.length.should.be.eql(0)
+		})
+	})
+
+	/*
+	 * Test the /POST /api/pregnancy-centers route -- authenticated
+	 */
+	describe('/POST /api/pregnancy-centers', () => {
+		it('it should create a new pregnancy center and return the data', async () => {
+			const pregnancyCenter = {
+				address: {
+					line1:'586 Central Ave.\nAlbany, NY 12206',
+					location:{
+						'type':'Point',
+						'coordinates':[-73.7814005, 42.6722152]
+					}},
+				prcName:'Birthright of Albany',
+				phone:'+15184382978',
+				website:'http://www.birthright.org',
+				// primaryContactUser: {
+				// 	firstName: 'Joanna',
+				// 	lastName: 'Smith',
+				// 	email: 'email@email.org',
+				// 	phone: '+18884442222'
+				// },
+				services:{},
+			}
+			mockAuthenticate()
+			const res = await chai.request(server)
+				.post('/api/pregnancy-centers')
+				.set('origin', config.corsOriginWhitelist[0])
+				.send(pregnancyCenter)
+			res.should.have.status(201)
+			res.body.should.be.a('object')
+			res.body.should.have.property('address')
+			res.body.should.have.property('prcName')
+			res.body.should.have.property('_id')
+			res.body.should.have.property('website')
+			res.body.should.have.property('phone')
+			// res.body.should.have.property('primaryContactUser')
+			// res.body.primaryContactUser.firstName.should.equal('Joanna')
+			// res.body.primaryContactUser.lastName.should.equal('Smith')
+			// res.body.primaryContactUser.email.should.equal('email@email.org')
+			// res.body.primaryContactUser.phone.should.equal('+18884442222')
+			res.body.address.line1.should.equal('586 Central Ave.\nAlbany, NY 12206')
+			res.body.address.location.type.should.equal('Point')
+			res.body.address.location.coordinates.should.deep.equal(
+				[-73.7814005, 42.6722152])
+			res.body.prcName.should.equal('Birthright of Albany')
+			res.body.phone.should.equal('+15184382978')
+			res.body.website.should.equal('http://www.birthright.org')
+		})
+	})
+
+	/*
+	 * Test the GET /api/pregnancy-centers/near-me' route w/o authentication
+	 */
+	describe('/GET /api/pregnancy-centers/near-me no-auth', () => {
+		it('it should return a 401 error because there is no authentication', async () => {
+			try {
+				await chai.request(server)
+					.get('/api/pregnancy-centers/near-me')
+					.set('origin', config.corsOriginWhitelist[0])
+			} catch (err) {
+				assertUnauthenticatedError(err.response)
+			}
+		})
+	})
+
+	/*
+	 * Test the GET /api/pregnancy-centers/near-me' route with authentication
+	 */
+	describe('/GET /api/pregnancy-centers/near-me', () => {
+		it('it should return an array with only the Birthright of Albany in it, not the Bridge to Life', async () => {
+
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services': {}
+
+			})
+
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.9241081,
+							40.771253
+						]
+					},
+				},
+				'prcName': 'The Bridge To Life, Inc.',
+				'phone': '+17182743577',
+				'email': 'thebridgetolife@verizon.net',
+				'website': 'http://www.thebridgetolife.org',
+				services:{},
+			})
+
+			mockAuthenticate()
+			const res = await chai.request(server)
+				.get('/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5')
+				.set('origin', config.corsOriginWhitelist[0])
+			res.should.have.status(200)
+			res.body.should.be.a('array')
+			res.body.length.should.be.eql(1)
+			res.body[0].prcName.should.equal('Birthright of Albany')
+		})
+	})
+
+	/*
+	 * Test the /GET /api/pregnancy-centers/verify route w/o authentication
+	 */
+	describe('/GET /api/pregnancy-centers/verify no-auth', () => {
+		it('it should return a 401 error because there is no authentication', async () => {
+			try {
+				await chai.request(server)
+					.get('/api/pregnancy-centers/verify')
+					.set('origin', config.corsOriginWhitelist[0])
+			} catch (err) {
+				assertUnauthenticatedError(err.response)
+			}
+		})
+	})
+
+	/*
+	 * Test the /GET /api/pregnancy-centers/verify route with authentication
+	 */
+	describe('/GET /api/pregnancy-centers/verify', () => {
+		it('it should return a single pregnancy center were verified.address is null', async () => {
+
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'primaryContactPerson': {
+					'firstName': 'Donna'
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				services:{},
+
+			})
+
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.9241081,
+							40.771253
+						]
+					},
+				},
+				'prcName': 'The Bridge To Life, Inc.',
+				'phone': '+17182743577',
+				'email': 'thebridgetolife@verizon.net',
+				'website': 'http://www.thebridgetolife.org',
+				'services':{},
+				'verified': {
+					'address': {
+						'date': '2017-04-16T23:33:17.220Z'
+					}
+				}
+			})
+			mockAuthenticate()
+
+			const res = await chai.request(server)
+				.get('/api/pregnancy-centers/verify')
+				.set('origin', config.corsOriginWhitelist[0])
+			res.should.have.status(200)
+			res.body.should.be.a('object')
+			res.body.should.have.property('prcName')
+			res.body.prcName.should.equal('Birthright of Albany')
+			res.body.should.have.property('primaryContactPerson')
+			res.body.primaryContactPerson.firstName.should.equal('Donna')
+			res.body.verified.should.deep.equal({})
+
+		})
+	})
+
+	/*
+	 * Test the /GET /api/pregnancy-centers/verify route with authentication
+	 */
+	describe('/GET /api/pregnancy-centers/verify', () => {
+		it('it should return a 404 not found because all pregnancy centers have been verified', async () => {
+
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services':{},
+				'verified': {
+					'address': {
+						'date' : '2017-04-16T23:33:17.220Z'
+					}
+				}
+
+			})
+
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.9241081,
+							40.771253
+						]
+					},
+				},
+				'prcName': 'The Bridge To Life, Inc.',
+				'phone': '+17182743577',
+				'email': 'thebridgetolife@verizon.net',
+				'website': 'http://www.thebridgetolife.org',
+				'services': {},
+				'verified': {
+					'address': {
+						'date' : '2017-04-16T23:33:17.220Z'
+					}
+				}
+			})
+
+			mockAuthenticate()
+
+			try {
+				await chai.request(server)
+					.get('/api/pregnancy-centers/verify')
+					.set('origin', config.corsOriginWhitelist[0])
+			} catch (err) {
+				assertError(err.response, 404, 'Not Found')
+			}
+		})
+	})
+
+	/*
+	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route w/o authentication
+	 */
+	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId no-auth', () => {
+		it('it should return a 401 error because there is no authentication', async () => {
+
+			const pc = new PregnancyCenterModel({
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services': {},
+				'verified': {
+					'address': {
+						'date' : '2017-04-16T23:33:17.220Z'
+					}
+				}
+
+			})
+			await pc.save()
+
+			try {
+				await chai.request(server)
+					.put('/api/pregnancy-centers/'+pc._id)
+					.set('origin', config.corsOriginWhitelist[0])
+					.send(pc)
+			} catch (err) {
+				assertUnauthenticatedError(err.response)
+			}
+		})
+	})
+
+	/*
+	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route with authentication
+	 */
+	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId', () => {
+		it('it should return the updated pregnancyCenter record', async () => {
+
+			const oldValues = {
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services':{},
+				// primaryContactUser: {
+				// 	firstName: 'Joanna',
+				// 	lastName: 'Smith',
+				// 	email: 'email@email.org',
+				// 	phone: '+18884442222'
+				// },
+				'verified': {
+					'address': {
+						'date' : '2017-04-16T23:33:17.220Z'
+					}
+				}
+			}
+
+			const newValues = {
+				'address': {
+					'line1': 'New Address',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services':{},
+				// primaryContactUser: {
+				// 	firstName: 'Joanna B',
+				// 	lastName: 'Smith',
+				// 	email: 'email2@email.org',
+				// 	phone: '+18884442222'
+				// },
+				'verified': {
+					'address': {
+						'date' : '2017-04-16T23:33:17.220Z'
+					}
+				}
+			}
+
+			const testUser = await UserModel.findOne({ displayName: 'Kate Sills'})
+
+			const oldPCObj = await PregnancyCenterModel.create(oldValues)
+
+			mockAuthenticate()
+
+			const res = await chai.request(server)
+				.put('/api/pregnancy-centers/' + oldPCObj._id)
+				.set('origin', config.corsOriginWhitelist[0])
+				.send(newValues)
+
+			res.should.have.status(200)
+			log.info(res.body)
+			res.body.should.be.a('object')
+			res.body.should.have.property('_id')
+			res.body.should.have.property('prcName')
+			// res.body.should.have.property('primaryContactUser')
+			res.body._id.should.equal(String(oldPCObj._id))
+			res.body.prcName.should.equal('Birthright of Albany')
+			res.body.should.have.property('verified')
+			res.body.should.have.property('updated')
+			res.body.updated.should.have.property('address')
+			res.body.updated.address.should.have.property('userId')
+			res.body.updated.address.userId.should.equal(testUser._id.toString())
+			res.body.verified.should.have.property('address')
+
+			// check that the pregnancy center history is created as well.
+			const newPCObj = await PregnancyCenterHistoryModel.find({
+				pregnancyCenterId: oldPCObj._id
+			})
+			log.info(newPCObj)
+			newPCObj.should.have.length(1)
+		})
+	})
+
+	/*
+	 * Test the /GET /api/pregnancy-centers/:pregnancyCenterId route w/o authentication
+	 */
+	describe('/GET /api/pregnancy-centers/:pregnancyCenterId no-auth', () => {
+		it('it should return a 401 error because there is no authentication', async () => {
+
+			const pc = new PregnancyCenterModel({
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services':{}
+
+			})
+			await pc.save()
+
+			try {
+				await chai.request(server)
+					.get('/api/pregnancy-centers/'+pc._id)
+					.set('origin', config.corsOriginWhitelist[0])
+			} catch (err) {
+				assertUnauthenticatedError(err.response)
+			}
+		})
+	})
+
+	/*
+	 * Test the /GET /api/pregnancy-centers/:pregnancyCenterId route with authentication
+	 */
+	describe('/GET /api/pregnancy-centers/:pregnancyCenterId', () => {
+		it('it should return a single pregnancy center matching the id', async () => {
+
+			const pc = new PregnancyCenterModel({
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services':{}
+
+			})
+
+			await pc.save()
+
+			mockAuthenticate()
+			const res = await chai.request(server)
+				.get('/api/pregnancy-centers/'+pc._id)
+				.set('origin', config.corsOriginWhitelist[0])
+			res.should.have.status(200)
+			res.body.should.be.a('object')
+			res.body.should.have.property('_id')
+			res.body.should.have.property('prcName')
+			res.body._id.should.equal(String(pc._id))
+			res.body.prcName.should.equal('Birthright of Albany')
+			res.body.verified.should.deep.equal({})
+
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers address 1', () => {
+		it('validation should fail because the address is not an object ', async () => {
+
+			const testPCObj1 = {
+				address: 'My address' // should be an object with line1, line2, city, etc.
+			}
+
+			const validationObj = await Joi.validate(testPCObj1, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			validationObj.error.name.should.equal('ValidationError')
+			validationObj.error.message.should.equal('child "address" fails because ["address" must be an object]')
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers address 2', () => {
+		it('validation should fail because the location coordinates are reversed ', async () => {
+
+			const testPCObj2 = {
+				address: {
+					line1: '123 Main Street',
+					city: 'Albany',
+					state: 'NY',
+					location: {
+						type: 'Point',
+						coordinates: [
+							42.6722152,
+							-73.7814005 // lat, lng, reversed
+
+						]
+					},
+
+				}
+			}
+
+			const validationObj = await Joi.validate(testPCObj2, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+
+			validationObj.error.name.should.equal('ValidationError')
+			validationObj.error.message.should.equal('child "address" fails because [child "location" fails because [child "coordinates" fails because ["coordinates" at position 0 fails because ["0" must be less than or equal to -66], "coordinates" at position 1 fails because ["1" must be larger than or equal to 23]]]]')
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers address 3', () => {
+		it('validation should fail because the location coordinates are reversed ', async () => {
+
+			const testPCObj3 = {
+				address: {
+					line1: '123 Main Street',
+					city: 'Albany',
+					state: 'NY',
+					location: {
+						type: 'Point',
+						coordinates: [
+							42.6722152,
+							-73.7814005 // lat, lng, reversed
+
+						]
+					},
+
+				}
+			}
+
+			const validationObj = await Joi.validate(testPCObj3, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			validationObj.error.name.should.equal('ValidationError')
+			validationObj.error.message.should.equal('child "address" fails because [child "location" fails because [child "coordinates" fails because ["coordinates" at position 0 fails because ["0" must be less than or equal to -66], "coordinates" at position 1 fails because ["1" must be larger than or equal to 23]]]]')
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers dateCreated 4', () => {
+		it('validation should fail because the dateCreated provided is not a date ', async () => {
+
+			const testPCObj4 = {
+				dateCreated: '3/3/2017'
+			}
+
+			const validationObj = await Joi.validate(testPCObj4, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			validationObj.error.name.should.equal('ValidationError')
+			validationObj.error.message.should.equal('child "dateCreated" fails because ["dateCreated" must be a valid ISO 8601 date]')
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers hours 6', () => {
+		it('validation should pass because hours follow this format', async () => {
+
+			const testPCObj6 = {
+				hours: {
+					2: [{
+						open: 800,
+						close: 1700
+					}]
+				}
+			}
+
+			const validationObj = await Joi.validate(testPCObj6, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			if (validationObj.error) {
+				throw validationObj.error
+			}
+			const validatedData = validationObj.value
+			validatedData.hours.should.deep.equal({
+				2: [{
+					open: 800,
+					close: 1700
+				}]
+			})
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers readable hours 7', () => {
+		it('validation should fail because tues is not one of the keys (it\'s 1-7)', async () => {
+
+			const testPCObj7 = {
+				hours: {
+					tues: [{
+						open: '800',
+						close: '1700'
+					}]
+				}
+			}
+
+			const validationObj = await Joi.validate(testPCObj7, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			validationObj.error.name.should.equal('ValidationError')
+			validationObj.error.message.should.equal('child "hours" fails because ["tues" is not allowed]')
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers hours 8', () => {
+		it('validation should pass because hours follow this format', async () => {
+
+			const testPCObj8 = {
+				hours: {
+					1: [{
+						open: 800,
+						close: 1600,
+					}]
+				}
+			}
+
+			const validationObj = await Joi.validate(testPCObj8, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			if (validationObj.error) {
+				throw validationObj.error
+			}
+			const validatedData = validationObj.value
+
+			validatedData.hours.should.deep.equal({
+				1: [{
+					open: 800,
+					close: 1600,
+				}]
+			})
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers phone 9', () => {
+		it('validation should fail because phone is in format xxx.xxx.xxx and needs to be in E.164 international format', async () => {
+
+			const testPCObj9 = {
+				phone: '888.444.2222'
+			}
+
+			const validationObj = await Joi.validate(testPCObj9, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			validationObj.error.name.should.equal('ValidationError')
+			validationObj.error.message.should.equal('child "phone" fails because ["phone" needs to be a valid phone number according to E.164 international format]')
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers phone 10', () => {
+		it('validation should pass because phone is in E.164 international format', async () => {
+
+			const testPCObj10 = {
+				phone: '+18884442222'
+			}
+
+			const validationObj = await Joi.validate(testPCObj10, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			if (validationObj.error) {
+				throw validationObj.error
+			}
+			const validatedData = validationObj.value
+			validatedData.phone.should.equal('+18884442222')
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers services 12', () => {
+		it('validation should fail because one of the services is mispelled', async () => {
+
+			const testPCObj12 = {
+				services: {
+					Ulllltrasound: false,
+					parentingClasses: true,
+				}
+			}
+
+			const validationObj = await Joi.validate(testPCObj12, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			validationObj.error.name.should.equal('ValidationError')
+			validationObj.error.message.should.equal('child "services" fails because ["Ulllltrasound" is not allowed]')
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers verified 13', () => {
+		it('validation should fail because each verified field object only has keys date and userId', async () => {
+
+			const testPCObj13 = {
+				verified: {
+					address: {
+						dateVerified: moment()
+					}
+				}
+			}
+
+			const validationObj = await Joi.validate(testPCObj13, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			validationObj.error.name.should.equal('ValidationError')
+			validationObj.error.message.should.equal('child "verified" fails because [child "address" fails because ["dateVerified" is not allowed]]')
+		})
+	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers verified 13', () => {
+		it('validation should pass because the verified field for address has date and userId', async () => {
+
+			const testPCObj13 = {
+				verified: {
+					address: {
+						date: moment().toISOString(),
+						userId: '58e46a8d210140d7e47bf58b'
+					}
+				}
+			}
+
+			const validationObj = await Joi.validate(testPCObj13, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+			if (validationObj.error) {
+				throw validationObj.error
+			}
+			const validatedData = validationObj.value
+			validatedData.verified.address.userId.should.equal('58e46a8d210140d7e47bf58b')
+		})
+	})
+})

--- a/server/persons/schema/joi-schema.js
+++ b/server/persons/schema/joi-schema.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const phoneValidator = require('joi-phone-validator')
 
-const pregnancyCenterSchemaJoi = Joi.object().keys({
+const personSchemaJoi = Joi.object().keys({
 	__v: Joi.number().min(0),
 	_id: Joi.string(),
 	createdAt: Joi.date().iso(),
@@ -11,8 +11,8 @@ const pregnancyCenterSchemaJoi = Joi.object().keys({
 	firstName: Joi.string(),
 	lastName: Joi.string(),
 	phone: phoneValidator.phone().validate(),
-	updatedAt: Joi.date().iso(),
+	updatedAt: Joi.date().iso()
 })
 
-module.exports = pregnancyCenterSchemaJoi
+module.exports = personSchemaJoi
 

--- a/server/persons/schema/joi-schema.js
+++ b/server/persons/schema/joi-schema.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const Joi = require('joi')
+const phoneValidator = require('joi-phone-validator')
+
+const pregnancyCenterSchemaJoi = Joi.object().keys({
+	__v: Joi.number().min(0),
+	_id: Joi.string(),
+	createdAt: Joi.date().iso(),
+	email: Joi.string().email(),
+	firstName: Joi.string(),
+	lastName: Joi.string(),
+	phone: phoneValidator.phone().validate(),
+	updatedAt: Joi.date().iso(),
+})
+
+module.exports = pregnancyCenterSchemaJoi
+

--- a/server/pregnancy-centers/schema/joi-schema.js
+++ b/server/pregnancy-centers/schema/joi-schema.js
@@ -54,7 +54,6 @@ const pregnancyCenterSchemaJoi = Joi.object().keys({
 	_id: Joi.string(),
 	address: addressSchemaJoi,
 	createdAt: Joi.date().iso(),
-	dateCreated: Joi.date().iso(),
 	hours: hoursSchemaJoi,
 	prcName: Joi.string(),
 	notes: Joi.string(),

--- a/server/pregnancy-centers/schema/joi-schema.js
+++ b/server/pregnancy-centers/schema/joi-schema.js
@@ -3,6 +3,8 @@
 const Joi = require('joi')
 const phoneValidator = require('joi-phone-validator')
 
+const personSchemaJoi = require('../../persons/schema/joi-schema')
+
 const pointSchemaJoi = Joi.object().keys({
 	_id: Joi.string(),
 	type: Joi.string().valid('Point').required(),
@@ -58,13 +60,7 @@ const pregnancyCenterSchemaJoi = Joi.object().keys({
 	prcName: Joi.string(),
 	notes: Joi.string(),
 	phone: phoneValidator.phone().validate(),
-	primaryContactPerson: {
-		firstName: Joi.string(),
-		lastName: Joi.string(),
-		email: Joi.string(),
-		phone: Joi.string()
-	},
-	primaryContactPersonId: Joi.string(),
+	primaryContactPerson: personSchemaJoi,
 	services: {
 		pregnancyTest: Joi.boolean(),
 		ultrasound: Joi.boolean(),

--- a/server/pregnancy-centers/schema/mongoose-schema.js
+++ b/server/pregnancy-centers/schema/mongoose-schema.js
@@ -3,7 +3,6 @@
 const _ = require('lodash')
 const Log = require('log')
 const mongoose = require('mongoose')
-const databaseHelpers = require('../../util/database-helpers')
 
 const log = new Log('info')
 
@@ -77,14 +76,6 @@ pregnancyCenterSchema.methods.getFullAddress = function getFullAddress() {
 		+ _.get(this, 'address.city', '') + ' ' + _.get(this, 'address.state', '') + ' ' +
 		_.get(this, 'address.zip', '')
 }
-
-pregnancyCenterSchema.pre('validate', async function(next) {
-	// depopulate the primaryContactPerson and replace with id only.
-	if (this.primaryContactPerson !== null && typeof this.primaryContactPerson  === 'object') {
-		this.primaryContactPerson = await databaseHelpers.updateCreatePrimaryContactPerson(this.primaryContactPerson)
-	}
-	next()
-})
 
 pregnancyCenterSchema.post('init', function(doc) {
 	log.info('%s has been initialized from the db', doc._id)

--- a/server/pregnancy-centers/schema/mongoose-schema.js
+++ b/server/pregnancy-centers/schema/mongoose-schema.js
@@ -2,6 +2,7 @@
 
 const mongoose = require('mongoose')
 const _ = require('lodash')
+const PersonModel = require('../../persons/schema/mongoose-schema')
 
 const pointSchema = new mongoose.Schema({
 	type: {type: String},
@@ -29,7 +30,7 @@ const pregnancyCenterSchema = mongoose.Schema({
 	prcName: String,
 	notes: String,
 	phone: String,
-	primaryContactPersonId: mongoose.Schema.Types.ObjectId,
+	primaryContactPerson: { type: mongoose.Schema.Types.ObjectId, ref: 'Persons' },
 	services: {
 		default: {},
 		pregnancyTest: Boolean,

--- a/server/pregnancy-centers/schema/mongoose-schema.js
+++ b/server/pregnancy-centers/schema/mongoose-schema.js
@@ -77,19 +77,6 @@ pregnancyCenterSchema.methods.getFullAddress = function getFullAddress() {
 		_.get(this, 'address.zip', '')
 }
 
-pregnancyCenterSchema.post('init', function(doc) {
-	log.info('%s has been initialized from the db', doc._id)
-})
-pregnancyCenterSchema.post('validate', function(doc) {
-	log.info('%s has been validated (but not saved yet)', doc._id)
-})
-pregnancyCenterSchema.post('save', function(doc) {
-	log.info('%s has been saved', doc._id)
-})
-pregnancyCenterSchema.post('remove', function(doc) {
-	log.info('%s has been removed', doc._id)
-})
-
 // create model using the schema
 const PregnancyCenterModel = mongoose.model('PregnancyCenters', pregnancyCenterSchema)
 

--- a/server/pregnancy-centers/schema/mongoose-schema.js
+++ b/server/pregnancy-centers/schema/mongoose-schema.js
@@ -1,10 +1,7 @@
 'use strict'
 
 const _ = require('lodash')
-const Log = require('log')
 const mongoose = require('mongoose')
-
-const log = new Log('info')
 
 const pointSchema = new mongoose.Schema({
 	type: {type: String},

--- a/server/server.js
+++ b/server/server.js
@@ -165,7 +165,7 @@ server.post('/api/pregnancy-centers', isLoggedInAPI, handleRejectedPromise(async
 	const newPregnancyCenter = req.body
 
 	try {
-		const createdPregnancyCenter = createPregnancyCenter(newPregnancyCenter)
+		const createdPregnancyCenter = await createPregnancyCenter(newPregnancyCenter)
 		res.status(201).json(createdPregnancyCenter)
 	} catch (err) {
 		return handleError(res, err)
@@ -179,8 +179,11 @@ server.post('/api/pregnancy-centers', isLoggedInAPI, handleRejectedPromise(async
 server.put('/api/pregnancy-centers/:pregnancyCenterId', isLoggedInAPI, checkPregnancyCenterId, handleRejectedPromise(async (req, res) => {
 	const pregnancyCenterId = req.params.pregnancyCenterId
 
+	log.info('got here')
+	log.info(req.user)
+
 	try {
-		const updatedPregnancyCenter = updatePregnancyCenter(req.user._id, pregnancyCenterId, req.body)
+		const updatedPregnancyCenter = await updatePregnancyCenter(req.user._id, pregnancyCenterId, req.body)
 		res.status(200).json(updatedPregnancyCenter)
 	} catch (err) {
 		return handleError(res, err)

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const _ = require('lodash')
 const bodyParser = require('body-parser')
 const boom = require('express-boom')
 const config = require('config')
@@ -17,7 +16,7 @@ const session = require('express-session')
 const PregnancyCenterModel = require('./pregnancy-centers/schema/mongoose-schema')
 const UserModel = require('./users/schema/mongoose-schema')
 
-const databaseHelpers = require('/util/database-helpers')
+const databaseHelpers = require('./util/database-helpers')
 const checkPregnancyCenterId = databaseHelpers.checkPregnancyCenterId
 const createPregnancyCenter = databaseHelpers.createPregnancyCenter
 const updatePregnancyCenter = databaseHelpers.updatePregnancyCenter

--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,6 @@ const config = require('config')
 const cors = require('cors')
 const express = require('express')
 const facebookTokenStrategy = require('passport-facebook-token')
-const Joi = require('joi')
 const Log = require('log')
 const mongoose = require('mongoose')
 const morgan = require('morgan')
@@ -15,10 +14,13 @@ const passport = require('passport')
 const P = require('bluebird')
 const session = require('express-session')
 
-const PregnancyCenterHistoryModel = require('./pregnancy-center-history/schema/mongoose-schema')
 const PregnancyCenterModel = require('./pregnancy-centers/schema/mongoose-schema')
-const pregnancyCenterSchemaJoi = require('./pregnancy-centers/schema/joi-schema')
 const UserModel = require('./users/schema/mongoose-schema')
+
+const databaseHelpers = require('/util/database-helpers')
+const checkPregnancyCenterId = databaseHelpers.checkPregnancyCenterId
+const createPregnancyCenter = databaseHelpers.createPregnancyCenter
+const updatePregnancyCenter = databaseHelpers.updatePregnancyCenter
 
 const port = config.server.port
 const server = express()
@@ -157,46 +159,14 @@ server.get('/api/pregnancy-centers/verify', isLoggedInAPI, handleRejectedPromise
 		return res.boom.notFound('No pregnancy centers to verify')
 	}
 
-	// This adds in the primaryContact from a separate User Collection
-	const primaryContactUserId = pregnancyCenter.primaryContactUserId
-
-	if (primaryContactUserId) {
-		const user = await UserModel.findOne({
-			_id: primaryContactUserId,
-		}).lean()
-
-		if (!user) {
-			return res.boom.notFound(`No user found by id: ${primaryContactUserId}`)
-		}
-
-		pregnancyCenter.primaryContactUser = {
-			firstName: user.firstName,
-			lastName: user.lastName,
-			email: user.email,
-			phone: user.phone
-		}
-	}
-
 	res.status(200).json(pregnancyCenter)
 }))
 
 server.post('/api/pregnancy-centers', isLoggedInAPI, handleRejectedPromise(async (req, res) => {
 	const newPregnancyCenter = req.body
 
-	const pregnancyCenterValidationObj = await Joi.validate(newPregnancyCenter, pregnancyCenterSchemaJoi, {
-		abortEarly: false
-	})
-
-	// Joi.validate() returns an obj of form { error: null, value: validatedData}
-	if (pregnancyCenterValidationObj.error) {
-		return handleJoiValidationError(res, pregnancyCenterValidationObj.error)
-	}
-
-	const validatedPregnancyCenter = pregnancyCenterValidationObj.value
 	try {
-		const createdPregnancyCenter = new PregnancyCenterModel(validatedPregnancyCenter)
-		await createdPregnancyCenter.save()
-
+		const createdPregnancyCenter = createPregnancyCenter(newPregnancyCenter)
 		res.status(201).json(createdPregnancyCenter)
 	} catch (err) {
 		return handleError(res, err)
@@ -207,32 +177,15 @@ server.post('/api/pregnancy-centers', isLoggedInAPI, handleRejectedPromise(async
 	Updates an existing pregnancy center, validates data first, adds 'updated' attribute and history model
 	Returns the updated pregnancy center
  */
-server.put('/api/pregnancy-centers/:pregnancyCenterId', isLoggedInAPI, handleRejectedPromise(async (req, res) => {
+server.put('/api/pregnancy-centers/:pregnancyCenterId', isLoggedInAPI, checkPregnancyCenterId, handleRejectedPromise(async (req, res) => {
 	const pregnancyCenterId = req.params.pregnancyCenterId
 
-	if (!mongoose.Types.ObjectId.isValid(pregnancyCenterId)) {
-		return res.boom.badRequest(`Invalid pregnancyCenterId ${pregnancyCenterId}`)
+	try {
+		const updatedPregnancyCenter = updatePregnancyCenter(req.user._id, pregnancyCenterId, req.body)
+		res.status(200).json(updatedPregnancyCenter)
+	} catch (err) {
+		return handleError(res, err)
 	}
-
-	const pregnancyCenterValidationObj = await Joi.validate(req.body, pregnancyCenterSchemaJoi, {
-		abortEarly: false
-	})
-
-	// await Joi.validate() returns an obj of form { error: null, value: validatedData}
-	if (pregnancyCenterValidationObj.error) {
-		return handleJoiValidationError(res, pregnancyCenterValidationObj.error)
-	}
-	const validatedPregnancyCenter = pregnancyCenterValidationObj.value
-	const validatedDataWithUpdatedHistory = await createUpdateHistory(req, validatedPregnancyCenter)
-	const pregnancyCenter = await PregnancyCenterModel.findByIdAndUpdate(pregnancyCenterId, {
-		$set: validatedDataWithUpdatedHistory
-	}, { new: true })
-
-	if (!pregnancyCenter) {
-		return res.boom.notFound(`Pregnancy Center not found with id ${pregnancyCenterId}`)
-	}
-
-	res.status(200).json(pregnancyCenter)
 }))
 
 /*
@@ -251,9 +204,7 @@ server.get('/api/pregnancy-centers/open-now', isLoggedInAPI, handleRejectedPromi
 			close: {$gte: time}
 		}
 	}
-	log.info(JSON.stringify(query))
-
-	const pregnancyCentersOpenNow = await PregnancyCenterModel.find(query)
+	const pregnancyCentersOpenNow = await PregnancyCenterModel.find(query).populate('primaryContactPerson').lean()
 	if (pregnancyCentersOpenNow.length <= 0) {
 		return res.boom.notFound(`No pregnancy centers open now ${dayOfWeek} ${time}`)
 	}
@@ -265,14 +216,10 @@ server.get('/api/pregnancy-centers/open-now', isLoggedInAPI, handleRejectedPromi
 	Returns the pregnancy center that matches the id
  */
 
-server.get('/api/pregnancy-centers/:pregnancyCenterId', isLoggedInAPI, handleRejectedPromise(async (req, res) => {
+server.get('/api/pregnancy-centers/:pregnancyCenterId', isLoggedInAPI, checkPregnancyCenterId, handleRejectedPromise(async (req, res) => {
 	const pregnancyCenterId = req.params.pregnancyCenterId
 
-	if (!mongoose.Types.ObjectId.isValid(pregnancyCenterId)) {
-		return res.boom.badRequest(`Invalid pregnancyCenterId: ${pregnancyCenterId}`)
-	}
-
-	const pregnancyCenter = await PregnancyCenterModel.findById(pregnancyCenterId)
+	const pregnancyCenter = await PregnancyCenterModel.findById(pregnancyCenterId).populate('primaryContactPerson').lean()
 
 	if (!pregnancyCenter) {
 		return res.boom.notFound(`No pregnancy center found with id: ${pregnancyCenterId}`)
@@ -285,77 +232,9 @@ server.listen(port, function () {
 	log.info(`Help Assist Her server listening on port ${port}`)
 })
 
-function handleJoiValidationError(res, err) {
-	log.error(err)
-	const data = _.clone( err['_object'])
-	delete err['_object']
-	return res.boom.badRequest(err, data)
-}
-
 function handleError(res, err) {
 	log.error(err)
-	return res.boom.badImplementation()
-}
-
-const keysToIgnore = ['_id', '__v', 'updated', 'updatedAt']
-
-function removeMongooseKeys(obj) {
-	for (const key in obj) {
-		if (keysToIgnore.includes(key)) {
-			delete obj[key]
-		} else if (typeof obj[key] == 'object' && obj.hasOwnProperty(key)) {
-			removeMongooseKeys(obj[key])
-		}
-	}
-	return obj
-}
-
-function isEqualMongoose(a, b){
-	return _.isEqual(removeMongooseKeys(a), removeMongooseKeys(b))
-}
-
-function createUpdateHistory(req, pregnancyCenterRawObj) {
-
-	return new P( async (resolve, reject) => {
-		const pregnancyCenterId = req.params['pregnancyCenterId']
-		const pregnancyCenterRawObjWithStamps = removeMongooseKeys(_.clone(pregnancyCenterRawObj))
-
-		let oldPregnancyCenterObj = await PregnancyCenterModel.findById(pregnancyCenterId)
-		if (!oldPregnancyCenterObj) {
-			reject()
-		}
-
-		oldPregnancyCenterObj = oldPregnancyCenterObj.toObject()
-
-		_.forOwn(pregnancyCenterRawObj, (value, key) => {
-
-			// check that the 'new' data isn't exactly the same as old
-			// this prevents us from creating histories for an update with same exact data
-			if (!keysToIgnore.includes(key) && !isEqualMongoose(oldPregnancyCenterObj[key],value)) {
-				if (oldPregnancyCenterObj.hasOwnProperty('updated')) {
-					pregnancyCenterRawObjWithStamps['updated'] = oldPregnancyCenterObj['updated']
-				} else {
-					pregnancyCenterRawObjWithStamps['updated'] = {}
-				}
-				pregnancyCenterRawObjWithStamps['updated'][key] = {
-					userId: req.user._id,
-					date: new Date().toISOString()
-				}
-
-				const pregnancyCenterHistoryObj = new PregnancyCenterHistoryModel({
-					pregnancyCenterId: pregnancyCenterId,
-					field: key,
-					newValue: value,
-					oldValue: oldPregnancyCenterObj[key],
-					userId: req.user._id,
-				})
-				pregnancyCenterHistoryObj.save()
-			}
-		})
-
-		resolve(pregnancyCenterRawObjWithStamps)
-
-	})
+	return res.boom.badImplementation(err)
 }
 
 server.get(

--- a/server/server.js
+++ b/server/server.js
@@ -110,7 +110,7 @@ startDatabase()
 	TODO: limits and paging, if necessary
  */
 server.get('/api/pregnancy-centers', isLoggedInAPI, handleRejectedPromise(async (req, res) => {
-	const allPregnancyCenters = await PregnancyCenterModel.find({})
+	const allPregnancyCenters = await PregnancyCenterModel.find({}).populate('primaryContactPerson').lean()
 	if (allPregnancyCenters) {
 		res.status(200).json(allPregnancyCenters)
 	}
@@ -138,7 +138,7 @@ server.get('/api/pregnancy-centers/near-me', isLoggedInAPI, handleRejectedPromis
 				$maxDistance: miles * METERS_PER_MILE
 			}
 		}
-	})
+	}).populate('primaryContactPerson').lean()
 
 	if (pregnancyCentersNearMe.length <= 0) {
 		return res.boom.notFound(`No pregnancy centers found near lat ${lat}, lng ${lng}, miles ${miles}`)

--- a/server/server.js
+++ b/server/server.js
@@ -127,8 +127,6 @@ server.get('/api/pregnancy-centers/near-me', isLoggedInAPI, handleRejectedPromis
 	const lat = req.query.lat || 42.6721989
 	const miles = req.query.miles || 5
 
-	log.info({'lat': lat, 'lng': lng, 'miles': miles})
-
 	const pregnancyCentersNearMe = await PregnancyCenterModel.find({
 		'address.location': {
 			$nearSphere: {
@@ -178,9 +176,6 @@ server.post('/api/pregnancy-centers', isLoggedInAPI, handleRejectedPromise(async
  */
 server.put('/api/pregnancy-centers/:pregnancyCenterId', isLoggedInAPI, checkPregnancyCenterId, handleRejectedPromise(async (req, res) => {
 	const pregnancyCenterId = req.params.pregnancyCenterId
-
-	log.info('got here')
-	log.info(req.user)
 
 	try {
 		const updatedPregnancyCenter = await updatePregnancyCenter(req.user._id, pregnancyCenterId, req.body)
@@ -242,7 +237,6 @@ function handleError(res, err) {
 server.get(
 	'/auth/facebook/token',
 	(req, res, next) => {
-		log.info(req.session)
 		passport.authenticate('facebook-token', (error, user) => {
 			if (error || !user) {
 				res.boom.unauthorized('User is not logged in.')

--- a/server/server.js
+++ b/server/server.js
@@ -151,7 +151,7 @@ server.get('/api/pregnancy-centers/near-me', isLoggedInAPI, handleRejectedPromis
 	Returns one pregnancy center that needs verification (currently defined as not having a verified address)
 */
 server.get('/api/pregnancy-centers/verify', isLoggedInAPI, handleRejectedPromise(async (req, res) => {
-	const pregnancyCenter = await PregnancyCenterModel.findOne({}).lean()
+	const pregnancyCenter = await PregnancyCenterModel.findOne({}).populate('primaryContactPerson').lean()
 
 	if (!pregnancyCenter) {
 		return res.boom.notFound('No pregnancy centers to verify')

--- a/server/util/database-helpers.js
+++ b/server/util/database-helpers.js
@@ -2,14 +2,17 @@
 
 const _ = require('lodash')
 const Joi = require('joi')
+const Log = require('log')
 const mongoose = require('mongoose')
 const P = require('bluebird')
 
-const PregnancyCenterHistoryModel = require('./pregnancy-center-history/schema/mongoose-schema')
-const PregnancyCenterModel = require('./pregnancy-centers/schema/mongoose-schema')
-const PersonModel = require('./persons/schema/mongoose-schema')
-const pregnancyCenterSchemaJoi = require('./pregnancy-centers/schema/joi-schema')
-const personSchemaJoi = require('./persons/schema/joi-schema')
+const PregnancyCenterHistoryModel = require('../pregnancy-center-history/schema/mongoose-schema')
+const PregnancyCenterModel = require('../pregnancy-centers/schema/mongoose-schema')
+const PersonModel = require('../persons/schema/mongoose-schema')
+const pregnancyCenterSchemaJoi = require('../pregnancy-centers/schema/joi-schema')
+const personSchemaJoi = require('../persons/schema/joi-schema')
+
+const log = new Log('info')
 
 const keysToIgnore = ['_id', '__v', 'updated', 'updatedAt']
 
@@ -131,7 +134,7 @@ module.exports = {
 			}
 
 			try {
-				const createdPregnancyCenter = new PregnancyCenterModel(pregnancyCenterValidationObj.value)
+				const createdPregnancyCenter = new PregnancyCenterModel(validatedPregnancyCenter)
 				await createdPregnancyCenter.save()
 				resolve(createdPregnancyCenter)
 			} catch (err) {
@@ -142,15 +145,19 @@ module.exports = {
 	updatePregnancyCenter: (userId, pregnancyCenterId, pregnancyCenter) => {
 		return new P(async(resolve, reject) => {
 
+			log.info('hit this')
+
 			const pregnancyCenterValidationObj = await Joi.validate(pregnancyCenter, pregnancyCenterSchemaJoi, {
 				abortEarly: false
 			})
 
 			// await Joi.validate() returns an obj of form { error: null, value: validatedData}
 			if (pregnancyCenterValidationObj.error) {
+				log.error(pregnancyCenterValidationObj.error)
 				reject(pregnancyCenterValidationObj.error)
 			}
 			const validatedPregnancyCenter = pregnancyCenterValidationObj.value
+			log.info(validatedPregnancyCenter)
 
 			const primaryContactPerson = validatedPregnancyCenter.primaryContactPerson
 			delete validatedPregnancyCenter.primaryContactPerson

--- a/server/util/database-helpers.js
+++ b/server/util/database-helpers.js
@@ -1,0 +1,30 @@
+const Joi = require('joi')
+const P = require('bluebird')
+
+const PregnancyCenterModel = require('./pregnancy-centers/schema/mongoose-schema')
+const pregnancyCenterSchemaJoi = require('./pregnancy-centers/schema/joi-schema')
+
+module.exports = {
+
+	createPregnancyCenter: (pregnancyCenter) => {
+
+		return new P(async(resolve, reject) => {
+			const pregnancyCenterValidationObj = await Joi.validate(pregnancyCenter, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+
+			// Joi.validate() returns an obj of form { error: null, value: validatedData}
+			if (pregnancyCenterValidationObj.error) {
+				reject(pregnancyCenterValidationObj.error)
+			}
+
+			try {
+				const createdPregnancyCenter = new PregnancyCenterModel(pregnancyCenterValidationObj.value)
+				await createdPregnancyCenter.save()
+				resolve(createdPregnancyCenter)
+			} catch (err) {
+				reject(err)
+			}
+		})
+	}
+}

--- a/server/util/database-helpers.js
+++ b/server/util/database-helpers.js
@@ -1,8 +1,107 @@
+'use strict'
+
+const _ = require('lodash')
 const Joi = require('joi')
+const mongoose = require('mongoose')
 const P = require('bluebird')
 
+const PregnancyCenterHistoryModel = require('./pregnancy-center-history/schema/mongoose-schema')
 const PregnancyCenterModel = require('./pregnancy-centers/schema/mongoose-schema')
+const PersonModel = require('./persons/schema/mongoose-schema')
 const pregnancyCenterSchemaJoi = require('./pregnancy-centers/schema/joi-schema')
+const personSchemaJoi = require('./persons/schema/joi-schema')
+
+const keysToIgnore = ['_id', '__v', 'updated', 'updatedAt']
+
+function removeMongooseKeys(obj) {
+	for (const key in obj) {
+		if (keysToIgnore.includes(key)) {
+			delete obj[key]
+		} else if (typeof obj[key] == 'object' && obj.hasOwnProperty(key)) {
+			removeMongooseKeys(obj[key])
+		}
+	}
+	return obj
+}
+
+function isEqualMongoose(a, b){
+	return _.isEqual(removeMongooseKeys(a), removeMongooseKeys(b))
+}
+
+function createUpdateHistory(userId, pregnancyCenterId, pregnancyCenterRawObj) {
+
+	return new P( async (resolve, reject) => {
+		const pregnancyCenterRawObjWithStamps = removeMongooseKeys(_.clone(pregnancyCenterRawObj))
+
+		let oldPregnancyCenterObj = await PregnancyCenterModel.findById(pregnancyCenterId)
+		if (!oldPregnancyCenterObj) {
+			reject()
+		}
+
+		oldPregnancyCenterObj = oldPregnancyCenterObj.toObject()
+
+		if (oldPregnancyCenterObj.hasOwnProperty('updated')) {
+			pregnancyCenterRawObjWithStamps['updated'] = oldPregnancyCenterObj['updated']
+		} else {
+			pregnancyCenterRawObjWithStamps['updated'] = {}
+		}
+
+		_.forOwn(pregnancyCenterRawObj, (value, key) => {
+
+			// check that the 'new' data isn't exactly the same as old
+			// this prevents us from creating histories for an update with same exact data
+			if (!keysToIgnore.includes(key) && !isEqualMongoose(oldPregnancyCenterObj[key],value)) {
+				pregnancyCenterRawObjWithStamps['updated'][key] = {
+					userId: userId,
+					date: new Date().toISOString()
+				}
+
+				const pregnancyCenterHistoryObj = new PregnancyCenterHistoryModel({
+					pregnancyCenterId: pregnancyCenterId,
+					field: key,
+					newValue: value,
+					oldValue: oldPregnancyCenterObj[key],
+					userId: userId,
+				})
+				pregnancyCenterHistoryObj.save()
+			}
+		})
+
+		resolve(pregnancyCenterRawObjWithStamps)
+
+	})
+}
+
+function updateCreatePrimaryContactPerson(primaryContactPerson) {
+	return new P( async (resolve, reject) => {
+		let createdPrimaryContactPerson
+
+		const personValidationObj = await Joi.validate(primaryContactPerson, personSchemaJoi, {
+			abortEarly: false
+		})
+
+		// Joi.validate() returns an obj of form { error: null, value: validatedData}
+		if (personValidationObj.error) {
+			reject(personValidationObj.error)
+		}
+
+		const validatedPrimaryContactPerson = personValidationObj.value
+
+		if ('_id' in primaryContactPerson) {
+			createdPrimaryContactPerson = await PersonModel.findByIdAndUpdate(validatedPrimaryContactPerson._id, {
+				$set: primaryContactPerson
+			}, {new: true})
+		} else {
+			try {
+				createdPrimaryContactPerson = new PersonModel(primaryContactPerson)
+				await createdPrimaryContactPerson.save()
+			} catch (err) {
+				reject(err)
+			}
+		}
+		resolve(createdPrimaryContactPerson._id)
+	})
+}
 
 module.exports = {
 
@@ -18,6 +117,19 @@ module.exports = {
 				reject(pregnancyCenterValidationObj.error)
 			}
 
+			const validatedPregnancyCenter = pregnancyCenterValidationObj.value
+
+			const primaryContactPerson = validatedPregnancyCenter.primaryContactPerson
+			delete validatedPregnancyCenter.primaryContactPerson
+
+			if (primaryContactPerson) {
+				try {
+					validatedPregnancyCenter.primaryContactPerson = await updateCreatePrimaryContactPerson(primaryContactPerson)
+				} catch (err) {
+					reject(err)
+				}
+			}
+
 			try {
 				const createdPregnancyCenter = new PregnancyCenterModel(pregnancyCenterValidationObj.value)
 				await createdPregnancyCenter.save()
@@ -26,5 +138,49 @@ module.exports = {
 				reject(err)
 			}
 		})
+	},
+	updatePregnancyCenter: (userId, pregnancyCenterId, pregnancyCenter) => {
+		return new P(async(resolve, reject) => {
+
+			const pregnancyCenterValidationObj = await Joi.validate(pregnancyCenter, pregnancyCenterSchemaJoi, {
+				abortEarly: false
+			})
+
+			// await Joi.validate() returns an obj of form { error: null, value: validatedData}
+			if (pregnancyCenterValidationObj.error) {
+				reject(pregnancyCenterValidationObj.error)
+			}
+			const validatedPregnancyCenter = pregnancyCenterValidationObj.value
+
+			const primaryContactPerson = validatedPregnancyCenter.primaryContactPerson
+			delete validatedPregnancyCenter.primaryContactPerson
+
+			if (primaryContactPerson) {
+				try {
+					validatedPregnancyCenter.primaryContactPerson = await updateCreatePrimaryContactPerson(primaryContactPerson)
+				} catch (err) {
+					reject(err)
+				}
+			}
+
+			const validatedDataWithUpdatedHistory = await createUpdateHistory(userId, pregnancyCenterId, validatedPregnancyCenter)
+			const updatedPregnancyCenter = await PregnancyCenterModel.findByIdAndUpdate(pregnancyCenterId, {
+				$set: validatedDataWithUpdatedHistory
+			}, {new: true})
+
+			if (!updatedPregnancyCenter) {
+				reject()
+			}
+
+			resolve(updatedPregnancyCenter)
+		})
+	},
+	checkPregnancyCenterId : (req, res, next) => {
+		const pregnancyCenterId = req.params.pregnancyCenterId
+
+		if (!mongoose.Types.ObjectId.isValid(pregnancyCenterId)) {
+			return res.boom.badRequest(`Invalid pregnancyCenterId ${pregnancyCenterId}`)
+		}
+		next()
 	}
 }


### PR DESCRIPTION
## Description
This PR ensures that the `primaryContactPerson` is populated (embedded) into the pregnancy centers when they are returned. It also adds a `database-helpers` file that abstracts creating and updating pregnancy centers so that the `server` file is a lot cleaner. Some other changes:

- changes `primaryContactPersonId` to be `primaryContactPerson` and makes it a `ref`, to match the examples of [using populated fields](http://mongoosejs.com/docs/populate.html) and allow us to use `populate` . 
- adds a Person joi schema
- adds `checkPregnancyCenterId` as middleware rather than within each route. This tests whether the ObjectId passed as a parameter is valid
- takes out the database helper functions already in server, like the ones for creating the histories, and moves them to the `database-helpers` file
- adds `createPregnancyCenter` which abstracts the joi validation, primaryContact handling, and more. This can be called in one line from a route.
- adds `updatePregnancyCenter` which does similar things, but also handles creating the history and updates

## Test Plan
Uncomment the test.js file and run yarn test locally. It doesn't pass on the server due to a cors issue. 
