### PR TITLE
Add zendesk chat client

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <title>Help Assist Her</title>
+    <!-- Start of helpassisther Zendesk Widget script -->
+    <script>/*<![CDATA[*/window.zEmbed||function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function(){a.push(arguments)},window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try{o=s}catch(e){n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}o.open()._l=function(){var e=this.createElement("script");n&&(this.domain=n),e.id="js-iframe-async",e.src="https://assets.zendesk.com/embeddable_framework/main.js",this.t=+new Date,this.zendeskHost="helpassisther.zendesk.com",this.zEQueue=a,this.body.appendChild(e)},o.write('<body onload="document._l();">'),o.close()}();
+    /*]]>*/</script>
+    <!-- End of helpassisther Zendesk Widget script -->
 </head>
 <body>
     <div id='root'>Loading Help Assist Her</div>


### PR DESCRIPTION
## Description
I created a zendesk account so that users can send an email to `support@helpassisther.com` with bugs or workflow issues (basically anything that we can fix/make better in the UI). They also have a chat client so I added it to test it out. I think this would be really useful for the volunteers to provide quick feedback. Feedback welcome!

## Test Plan
Just load the site and you should see a Help button in the lower right.
