### PR TITLE
Added query capability and randomization to the /verify endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 addons:
   apt:
     sources:
-    - mongodb-3.0-precise
+    - mongodb-3.2-precise
     packages:
     - mongodb-org-server
 

--- a/server/data-import/test/test.js
+++ b/server/data-import/test/test.js
@@ -35,6 +35,7 @@ function mockUnauthenticate () {
 	server.request.isAuthenticated = function () {
 		return false
 	}
+	server.request.user = null
 }
 
 function assertError(res, statusCode, error, message=null, data=null) {
@@ -75,7 +76,7 @@ describe('PregnancyCenters', () => {
 		const someoneElse = new UserModel({
 			displayName: 'Someone Else'
 		})
-		return someoneElse.save()
+		await someoneElse.save()
 	})
 
 	/*

--- a/server/data-import/test/test.js
+++ b/server/data-import/test/test.js
@@ -467,7 +467,6 @@ describe('PregnancyCenters', () => {
 			res.body.should.be.a('object')
 			res.body.should.have.property('prcName')
 			res.body.primaryContactPerson.should.have.property('firstName')
-			res.body.verifiedData.should.deep.equal({})
  
 		})
 	})

--- a/server/data-import/test/test.js
+++ b/server/data-import/test/test.js
@@ -461,13 +461,13 @@ describe('PregnancyCenters', () => {
 			const res = await chai.request(server)
 				.get('/api/pregnancy-centers/verify')
 
+			// note that verification is randomized, so there is no guarantee of the resulting object
 			res.should.have.status(200)
 			res.body.should.be.a('object')
 			res.body.should.have.property('prcName')
-			res.body.prcName.should.equal('Birthright of Albany')
-			res.body.primaryContactPerson.firstName.should.equal('Joanna')
+			res.body.primaryContactPerson.should.have.property('firstName')
 			res.body.verifiedData.should.deep.equal({})
-
+ 
 		})
 	})
 

--- a/server/pregnancy-centers/queries.js
+++ b/server/pregnancy-centers/queries.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = {
+
+	neverVerified: {
+		'verifiedData': {},
+	},
+	verificationNotComplete: {
+		$or: [
+			{'verifiedData.address': {$exists: false}},
+			{'verifiedData.email': {$exists: false}},
+			{'verifiedData.hours': {$exists: false}},
+			{'verifiedData.prcName': {$exists: false}},
+			{'verifiedData.phone': {$exists: false}},
+			{'verifiedData.primaryContactPerson': {$exists: false}},
+			{'verifiedData.services': {$exists: false}},
+			{'verifiedData.website': {$exists: false}},
+		]
+	},
+	anything: {}
+}


### PR DESCRIPTION
## Description
I added a separate file for potential `PregnancyCenter` queries and imported them into the `server.js` file so we can switch them easily for whatever our use case is. One of those is `verificationNotComplete` which will return if any of the fields are not verified. I also added randomness so the user is not stuck on a single `PregnancyCenter` if they can't add more data.

## Test Plan
Because of randomization, the tests don't cover these changes, but they can be tested on the front end manually. 
