### PR TITLE
Change definition of a complete verification to not check primary contact. 

### DIFF
--- a/server/pregnancy-centers/queries.js
+++ b/server/pregnancy-centers/queries.js
@@ -12,7 +12,6 @@ module.exports = {
 			{'verifiedData.hours': {$exists: false}},
 			{'verifiedData.prcName': {$exists: false}},
 			{'verifiedData.phone': {$exists: false}},
-			{'verifiedData.primaryContactPerson': {$exists: false}},
 			{'verifiedData.services': {$exists: false}},
 			{'verifiedData.website': {$exists: false}},
 		]


### PR DESCRIPTION
## Description
Remove the check for whether primary contact has been verified. Now anything that has everything *but* the primary contact verified is deemed complete. Previously, volunteers were getting the same pregnancy center to verify again if they hadn't filled in the primary contact.

## Test Plan
Because it's such a small change, no additional tests. 
