### PR TITLE
Add 'closed' field to Pregnancy Center and FQHC

### DIFF
--- a/server/errors/app-validation-error.js
+++ b/server/errors/app-validation-error.js
@@ -1,0 +1,16 @@
+module.exports = class AppValidationError extends Error {
+	constructor (message) {
+
+		// Calling parent constructor of base Error class.
+		super(message)
+
+		// Saving class name in the property of our custom error as a shortcut.
+		this.name = this.constructor.name
+
+		// Capturing stack trace, excluding constructor call from it.
+		Error.captureStackTrace(this, this.constructor)
+		
+		this.status = 400
+
+	}
+}

--- a/server/fqhcs/schema/joi-schema.js
+++ b/server/fqhcs/schema/joi-schema.js
@@ -14,6 +14,7 @@ const fqhcSchemaJoi = Joi.object().keys({
 	_id: Joi.string(),
 	address: addressSchemaJoi,
 	classification: Joi.string(),
+	closed: Joi.boolean(),
 	createdAt: Joi.date().iso(),
 	email: Joi.string().email(),
 	hours: hoursSchemaJoi,
@@ -34,6 +35,7 @@ const fqhcSchemaJoi = Joi.object().keys({
 	},
 	updated: {
 		address: dateUserActionSchemaJoi,
+		closed: dateUserActionSchemaJoi,
 		email: dateUserActionSchemaJoi,
 		hours: dateUserActionSchemaJoi,
 		fqhcName: dateUserActionSchemaJoi,

--- a/server/fqhcs/schema/joi-schema.js
+++ b/server/fqhcs/schema/joi-schema.js
@@ -14,7 +14,7 @@ const fqhcSchemaJoi = Joi.object().keys({
 	_id: Joi.string(),
 	address: addressSchemaJoi,
 	classification: Joi.string(),
-	closed: Joi.boolean(),
+	outOfBusiness: Joi.boolean(),
 	createdAt: Joi.date().iso(),
 	email: Joi.string().email(),
 	hours: hoursSchemaJoi,
@@ -35,7 +35,7 @@ const fqhcSchemaJoi = Joi.object().keys({
 	},
 	updated: {
 		address: dateUserActionSchemaJoi,
-		closed: dateUserActionSchemaJoi,
+		outOfBusiness: dateUserActionSchemaJoi,
 		email: dateUserActionSchemaJoi,
 		hours: dateUserActionSchemaJoi,
 		fqhcName: dateUserActionSchemaJoi,

--- a/server/fqhcs/schema/mongoose-schema.js
+++ b/server/fqhcs/schema/mongoose-schema.js
@@ -12,6 +12,7 @@ const {
 const fqhcSchema = mongoose.Schema({
 	address: addressSchema,
 	classification: String,
+	closed: Boolean,
 	email: String,
 	hours: Object,
 	inVerification: String,
@@ -31,6 +32,7 @@ const fqhcSchema = mongoose.Schema({
 	},
 	updated: {
 		address: userDateSchema,
+		closed: userDateSchema,
 		email: userDateSchema,
 		hours: userDateSchema,
 		fqhcName: userDateSchema,

--- a/server/fqhcs/schema/mongoose-schema.js
+++ b/server/fqhcs/schema/mongoose-schema.js
@@ -12,7 +12,7 @@ const {
 const fqhcSchema = mongoose.Schema({
 	address: addressSchema,
 	classification: String,
-	closed: Boolean,
+	outOfBusiness: Boolean,
 	email: String,
 	hours: Object,
 	inVerification: String,
@@ -32,7 +32,7 @@ const fqhcSchema = mongoose.Schema({
 	},
 	updated: {
 		address: userDateSchema,
-		closed: userDateSchema,
+		outOfBusiness: userDateSchema,
 		email: userDateSchema,
 		hours: userDateSchema,
 		fqhcName: userDateSchema,

--- a/server/pregnancy-centers/schema/joi-schema.js
+++ b/server/pregnancy-centers/schema/joi-schema.js
@@ -15,6 +15,7 @@ const pregnancyCenterSchemaJoi = Joi.object().keys({
 	__v: Joi.number().min(0),
 	_id: objectIdValidator.objectId().isValid().allow(null),
 	address: addressSchemaJoi,
+	closed: Joi.boolean(),
 	createdAt: Joi.date().iso(),
 	email: Joi.string().email(),
 	hours: hoursSchemaJoi,
@@ -37,6 +38,7 @@ const pregnancyCenterSchemaJoi = Joi.object().keys({
 	},
 	updated: {
 		address: dateUserActionSchemaJoi,
+		closed: dateUserActionSchemaJoi,
 		email: dateUserActionSchemaJoi,
 		hours: dateUserActionSchemaJoi,
 		prcName: dateUserActionSchemaJoi,

--- a/server/pregnancy-centers/schema/joi-schema.js
+++ b/server/pregnancy-centers/schema/joi-schema.js
@@ -15,7 +15,7 @@ const pregnancyCenterSchemaJoi = Joi.object().keys({
 	__v: Joi.number().min(0),
 	_id: objectIdValidator.objectId().isValid().allow(null),
 	address: addressSchemaJoi,
-	closed: Joi.boolean(),
+	outOfBusiness: Joi.boolean(),
 	createdAt: Joi.date().iso(),
 	email: Joi.string().email(),
 	hours: hoursSchemaJoi,
@@ -38,7 +38,7 @@ const pregnancyCenterSchemaJoi = Joi.object().keys({
 	},
 	updated: {
 		address: dateUserActionSchemaJoi,
-		closed: dateUserActionSchemaJoi,
+		outOfBusiness: dateUserActionSchemaJoi,
 		email: dateUserActionSchemaJoi,
 		hours: dateUserActionSchemaJoi,
 		prcName: dateUserActionSchemaJoi,

--- a/server/pregnancy-centers/schema/mongoose-schema.js
+++ b/server/pregnancy-centers/schema/mongoose-schema.js
@@ -11,6 +11,7 @@ const {
 
 const pregnancyCenterSchema = mongoose.Schema({
 	address: addressSchema,
+	closed: Boolean,
 	email: String,
 	hours: Object,
 	inVerification: mongoose.Schema.Types.ObjectId,
@@ -32,6 +33,7 @@ const pregnancyCenterSchema = mongoose.Schema({
 	},
 	updated: {
 		address: userDateSchema,
+		closed: userDateSchema,
 		email: userDateSchema,
 		hours: userDateSchema,
 		prcName: userDateSchema,

--- a/server/pregnancy-centers/schema/mongoose-schema.js
+++ b/server/pregnancy-centers/schema/mongoose-schema.js
@@ -11,7 +11,7 @@ const {
 
 const pregnancyCenterSchema = mongoose.Schema({
 	address: addressSchema,
-	closed: Boolean,
+	outOfBusiness: Boolean,
 	email: String,
 	hours: Object,
 	inVerification: mongoose.Schema.Types.ObjectId,
@@ -33,7 +33,7 @@ const pregnancyCenterSchema = mongoose.Schema({
 	},
 	updated: {
 		address: userDateSchema,
-		closed: userDateSchema,
+		outOfBusiness: userDateSchema,
 		email: userDateSchema,
 		hours: userDateSchema,
 		prcName: userDateSchema,

--- a/server/server.js
+++ b/server/server.js
@@ -131,7 +131,7 @@ server.get('/api/initial-data', (req, res) => {
 	TODO: limits and paging, if necessary
  */
 server.get('/api/pregnancy-centers', isLoggedInAPI, handleRejectedPromise(async (req, res) => {
-	const allPregnancyCenters = await PregnancyCenterModel.find({closed:{$in: [null, false]}}).populate('primaryContactPerson').lean()
+	const allPregnancyCenters = await PregnancyCenterModel.find({outOfBusiness:{$in: [null, false]}}).populate('primaryContactPerson').lean()
 	if (allPregnancyCenters) {
 		res.status(200).json(allPregnancyCenters)
 	}
@@ -157,7 +157,7 @@ server.get('/api/pregnancy-centers/near-me', isLoggedInAPI, handleRejectedPromis
 				$maxDistance: miles * METERS_PER_MILE
 			}
 		},
-		closed: {$in: [null, false]}
+		outOfBusiness: {$in: [null, false]}
 	}).populate('primaryContactPerson').lean()
 
 	if (pregnancyCentersNearMe.length <= 0) {
@@ -231,7 +231,7 @@ server.put('/api/pregnancy-centers/:pregnancyCenterId', isLoggedInAPI, handleRej
 server.get('/api/pregnancy-centers/open-now', isLoggedInAPI, handleRejectedPromise(async (req, res) => {
 	const time = parseInt(req.query.time)
 	const dayOfWeek = parseInt(req.query.day)
-	const query = { closed: {$in: [null, false]}}
+	const query = { outOfBusiness: {$in: [null, false]}}
 
 	query['hours.' + dayOfWeek + '.open'] = {
 		$lte: time

--- a/server/server.js
+++ b/server/server.js
@@ -131,7 +131,7 @@ server.get('/api/initial-data', (req, res) => {
 	TODO: limits and paging, if necessary
  */
 server.get('/api/pregnancy-centers', isLoggedInAPI, handleRejectedPromise(async (req, res) => {
-	const allPregnancyCenters = await PregnancyCenterModel.find({}).populate('primaryContactPerson').lean()
+	const allPregnancyCenters = await PregnancyCenterModel.find({closed:{$in: [null, false]}}).populate('primaryContactPerson').lean()
 	if (allPregnancyCenters) {
 		res.status(200).json(allPregnancyCenters)
 	}
@@ -156,7 +156,8 @@ server.get('/api/pregnancy-centers/near-me', isLoggedInAPI, handleRejectedPromis
 				},
 				$maxDistance: miles * METERS_PER_MILE
 			}
-		}
+		},
+		closed: {$in: [null, false]}
 	}).populate('primaryContactPerson').lean()
 
 	if (pregnancyCentersNearMe.length <= 0) {
@@ -230,7 +231,7 @@ server.put('/api/pregnancy-centers/:pregnancyCenterId', isLoggedInAPI, handleRej
 server.get('/api/pregnancy-centers/open-now', isLoggedInAPI, handleRejectedPromise(async (req, res) => {
 	const time = parseInt(req.query.time)
 	const dayOfWeek = parseInt(req.query.day)
-	const query = {}
+	const query = { closed: {$in: [null, false]}}
 
 	query['hours.' + dayOfWeek + '.open'] = {
 		$lte: time
@@ -301,7 +302,7 @@ server.listen(port, function () {
 })
 
 function handleError(res, err) {
-	if (err.name === 'ValidationError') {
+	if (err.name === 'ValidationError' || err.name === 'AppValidationError') {
 		return res.boom.badRequest(err.message)
 	}
 	return res.boom.badImplementation(err)

--- a/server/test/fqhc-tests.js
+++ b/server/test/fqhc-tests.js
@@ -255,7 +255,6 @@ describe('FQHCs', () => {
 				fqhcId: oldFQHC._id
 			})
 			const fields = _.map(histories, 'field')
-			log.info(fields)
 			fields.should.have.members([ 
 				'fqhcName',
 				'phone',
@@ -263,6 +262,67 @@ describe('FQHCs', () => {
 				'services',
 				'verifiedData',
 				'address' ])
+		})
+	})
+
+	/*
+	 * Test the /PUT /api/fqhcs/:fqhcId route with authentication - closed == True
+	 */
+	describe('/PUT /api/fqhcs/:fqhcId', () => {
+		it('it should return a validation error because the original was closed', async () => {
+			await mockAuthenticate()
+
+			const oldValues = {
+				'address': {
+					'line1': '650 Fulton St	BROOKLYN, NY, 11217',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005, // this is fake data
+							42.6722152
+						]
+					},
+				},
+				closed: true,
+				'fqhcName': 'BROOKLYN PLAZA MEDICAL CENTER, INC.',
+				'phone': '+17185969800',
+				'website': 'www.brooklynplaza.org',
+				services: {},
+			}
+
+			const newValues = {
+				'address': {
+					'line1': 'New Address',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.99, // this is fake data
+							42.6722152
+						]
+					},
+				},
+				'fqhcName': 'New Name',
+				'phone': '+17185969899',
+				'website': 'www.newurl.org',
+				services: {'wellWomanCare': true},
+				verifiedData: {
+					address: {
+						date: '2017-04-16T23:33:17.220Z'
+					}
+				}
+			}
+
+			const oldFQHC = await FQHCModel.create(oldValues)
+			oldFQHC.closed.should.equal(true)
+			log.info('OLD CLOSED IS', oldFQHC.closed)
+			try {
+				await chai.request(server)
+					.put('/api/fqhcs/' + oldFQHC._id)
+					.send(newValues)
+				chai.assert.fail(0, 1, 'Error not thrown')	
+			} catch (err) {
+				assertError(err.response, 400, 'Bad Request', 'Cannot edit a closed FQHC')
+			}
 		})
 	})
 })

--- a/server/test/fqhc-tests.js
+++ b/server/test/fqhc-tests.js
@@ -266,10 +266,10 @@ describe('FQHCs', () => {
 	})
 
 	/*
-	 * Test the /PUT /api/fqhcs/:fqhcId route with authentication - closed == True
+	 * Test the /PUT /api/fqhcs/:fqhcId route with authentication - outOfBusiness == True
 	 */
 	describe('/PUT /api/fqhcs/:fqhcId', () => {
-		it('it should return a validation error because the original was closed', async () => {
+		it('it should return a validation error because the original was outOfBusiness', async () => {
 			await mockAuthenticate()
 
 			const oldValues = {
@@ -283,7 +283,7 @@ describe('FQHCs', () => {
 						]
 					},
 				},
-				closed: true,
+				outOfBusiness: true,
 				'fqhcName': 'BROOKLYN PLAZA MEDICAL CENTER, INC.',
 				'phone': '+17185969800',
 				'website': 'www.brooklynplaza.org',
@@ -313,15 +313,15 @@ describe('FQHCs', () => {
 			}
 
 			const oldFQHC = await FQHCModel.create(oldValues)
-			oldFQHC.closed.should.equal(true)
-			log.info('OLD CLOSED IS', oldFQHC.closed)
+			oldFQHC.outOfBusiness.should.equal(true)
+			log.info('OLD outOfBusiness IS', oldFQHC.outOfBusiness)
 			try {
 				await chai.request(server)
 					.put('/api/fqhcs/' + oldFQHC._id)
 					.send(newValues)
 				chai.assert.fail(0, 1, 'Error not thrown')	
 			} catch (err) {
-				assertError(err.response, 400, 'Bad Request', 'Cannot edit a closed FQHC')
+				assertError(err.response, 400, 'Bad Request', 'Cannot edit a outOfBusiness FQHC')
 			}
 		})
 	})

--- a/server/test/pregnancy-center-tests.js
+++ b/server/test/pregnancy-center-tests.js
@@ -139,7 +139,7 @@ describe('PregnancyCenters', () => {
 
 			})
 
-			// copy of the above model, but with closed = True - should not be returned
+			// copy of the above model, but with outOfBusiness = True - should not be returned
 			await PregnancyCenterModel.create({
 				'address': {
 					'line1': '586 Central Ave.\nAlbany, NY 12206',
@@ -151,8 +151,8 @@ describe('PregnancyCenters', () => {
 						]
 					},
 				},
-				closed: true,
-				'prcName': 'Birthright of Albany - Closed',
+				outOfBusiness: true,
+				'prcName': 'Birthright of Albany - outOfBusiness',
 				'phone': '+15184382978',
 				'primaryContactPerson': primaryContactPerson,
 				'website': 'http://www.birthright.org',
@@ -293,7 +293,7 @@ describe('PregnancyCenters', () => {
 						'coordinates': [-73.7814005, 42.6722152]
 					}
 				},
-				closed: true, // this shouldn't affect anything
+				outOfBusiness: true, // this shouldn't affect anything
 				prcName: 'Birthright of Albany',
 				phone: '+15184382978',
 				website: 'http://www.birthright.org',
@@ -314,7 +314,7 @@ describe('PregnancyCenters', () => {
 			res.should.have.status(201)
 			res.body.should.be.a('object')
 			res.body.should.have.property('address')
-			res.body.should.have.property('closed')
+			res.body.should.have.property('outOfBusiness')
 			res.body.should.have.property('prcName')
 			res.body.should.have.property('_id')
 			res.body.should.have.property('website')
@@ -385,7 +385,7 @@ describe('PregnancyCenters', () => {
 
 			})
 
-			// copy of above, but closed
+			// copy of above, but outOfBusiness
 			await PregnancyCenterModel.create({
 				'address': {
 					'line1': '586 Central Ave.\nAlbany, NY 12206',
@@ -397,9 +397,9 @@ describe('PregnancyCenters', () => {
 						]
 					},
 				},
-				closed: true,
+				outOfBusiness: true,
 				'primaryContactPerson': primaryContactPerson,
-				'prcName': 'Birthright of Albany - Closed',
+				'prcName': 'Birthright of Albany - outOfBusiness',
 				'phone': '+15184382978',
 				'website': 'http://www.birthright.org',
 				'services': {}
@@ -476,7 +476,7 @@ describe('PregnancyCenters', () => {
 						]
 					},
 				},
-				'closed': true, // should not affect things
+				'outOfBusiness': true, // should not affect things
 				'prcName': 'Birthright of Albany',
 				'primaryContactPerson': primaryContactPerson,
 				'phone': '+15184382978',
@@ -504,7 +504,7 @@ describe('PregnancyCenters', () => {
 						]
 					},
 				},
-				closed: true, // should not affect things
+				outOfBusiness: true, // should not affect things
 				'prcName': 'The Bridge To Life, Inc.',
 				'phone': '+17182743577',
 				'primaryContactPerson': primaryContactPerson2,
@@ -526,7 +526,7 @@ describe('PregnancyCenters', () => {
 			res.should.have.status(200)
 			res.body.should.be.a('object')
 			res.body.should.have.property('prcName')
-			res.body.should.have.property('closed')
+			res.body.should.have.property('outOfBusiness')
 			res.body.primaryContactPerson.should.have.property('firstName')
 
 		})
@@ -549,7 +549,7 @@ describe('PregnancyCenters', () => {
 						]
 					},
 				},
-				closed: true,
+				outOfBusiness: true,
 				'prcName': 'Birthright of Albany',
 				'phone': '+15184382978',
 				'website': 'http://www.birthright.org',
@@ -750,11 +750,11 @@ describe('PregnancyCenters', () => {
 	})
 
 	/*
-	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route with authentication and closed = True
-	 * original pc has been closed, trying to edit it without re-opening should be an error
+	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route with authentication and outOfBusiness = True
+	 * original pc has been outOfBusiness, trying to edit it without re-opening should be an error
 	 */
 	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId', () => {
-		it('original pc has been closed, trying to edit it without re-opening should be an error', async () => {
+		it('original pc has been outOfBusiness, trying to edit it without re-opening should be an error', async () => {
 			await mockAuthenticate()
 
 			const primaryContactPerson = new PersonModel({
@@ -776,7 +776,7 @@ describe('PregnancyCenters', () => {
 						]
 					},
 				},
-				'closed': true,
+				'outOfBusiness': true,
 				'prcName': 'Birthright of Albany',
 				'phone': '+15184382978',
 				'website': 'http://www.birthright.org',
@@ -828,7 +828,7 @@ describe('PregnancyCenters', () => {
 					.put('/api/pregnancy-centers/' + oldPCObj._id)
 					.send(newValues)
 			} catch (err) {
-				assertError(err.response, 400, 'Bad Request', 'Cannot edit a closed Pregnancy Center')
+				assertError(err.response, 400, 'Bad Request', 'Cannot edit a outOfBusiness Pregnancy Center')
 			}
 		})
 	})

--- a/server/test/pregnancy-center-tests.js
+++ b/server/test/pregnancy-center-tests.js
@@ -139,6 +139,33 @@ describe('PregnancyCenters', () => {
 
 			})
 
+			// copy of the above model, but with closed = True - should not be returned
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				closed: true,
+				'prcName': 'Birthright of Albany - Closed',
+				'phone': '+15184382978',
+				'primaryContactPerson': primaryContactPerson,
+				'website': 'http://www.birthright.org',
+				'services': {},
+				'hours': {
+					1: {
+						open: 800, // 8am
+						close: 1500 // 3pm
+					}// 1 is Monday
+				}
+
+			})
+
 			await PregnancyCenterModel.create({
 				'address': {
 					'line1': '23-40 Astoria Boulevard\nAstoria, NY 11102',
@@ -266,6 +293,7 @@ describe('PregnancyCenters', () => {
 						'coordinates': [-73.7814005, 42.6722152]
 					}
 				},
+				closed: true, // this shouldn't affect anything
 				prcName: 'Birthright of Albany',
 				phone: '+15184382978',
 				website: 'http://www.birthright.org',
@@ -286,6 +314,7 @@ describe('PregnancyCenters', () => {
 			res.should.have.status(201)
 			res.body.should.be.a('object')
 			res.body.should.have.property('address')
+			res.body.should.have.property('closed')
 			res.body.should.have.property('prcName')
 			res.body.should.have.property('_id')
 			res.body.should.have.property('website')
@@ -350,6 +379,27 @@ describe('PregnancyCenters', () => {
 				},
 				'primaryContactPerson': primaryContactPerson,
 				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services': {}
+
+			})
+
+			// copy of above, but closed
+			await PregnancyCenterModel.create({
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				closed: true,
+				'primaryContactPerson': primaryContactPerson,
+				'prcName': 'Birthright of Albany - Closed',
 				'phone': '+15184382978',
 				'website': 'http://www.birthright.org',
 				'services': {}
@@ -426,6 +476,7 @@ describe('PregnancyCenters', () => {
 						]
 					},
 				},
+				'closed': true, // should not affect things
 				'prcName': 'Birthright of Albany',
 				'primaryContactPerson': primaryContactPerson,
 				'phone': '+15184382978',
@@ -453,6 +504,7 @@ describe('PregnancyCenters', () => {
 						]
 					},
 				},
+				closed: true, // should not affect things
 				'prcName': 'The Bridge To Life, Inc.',
 				'phone': '+17182743577',
 				'primaryContactPerson': primaryContactPerson2,
@@ -474,6 +526,7 @@ describe('PregnancyCenters', () => {
 			res.should.have.status(200)
 			res.body.should.be.a('object')
 			res.body.should.have.property('prcName')
+			res.body.should.have.property('closed')
 			res.body.primaryContactPerson.should.have.property('firstName')
 
 		})
@@ -496,6 +549,7 @@ describe('PregnancyCenters', () => {
 						]
 					},
 				},
+				closed: true,
 				'prcName': 'Birthright of Albany',
 				'phone': '+15184382978',
 				'website': 'http://www.birthright.org',
@@ -692,6 +746,90 @@ describe('PregnancyCenters', () => {
 
 			const people = await PersonModel.find({})
 			people.should.have.length(1)
+		})
+	})
+
+	/*
+	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route with authentication and closed = True
+	 * original pc has been closed, trying to edit it without re-opening should be an error
+	 */
+	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId', () => {
+		it('original pc has been closed, trying to edit it without re-opening should be an error', async () => {
+			await mockAuthenticate()
+
+			const primaryContactPerson = new PersonModel({
+				firstName: 'Joanna',
+				lastName: 'Smith',
+				email: 'email@email.org',
+				phone: '+18884442222'
+			})
+			await primaryContactPerson.save()
+
+			const oldValues = {
+				'address': {
+					'line1': '586 Central Ave.\nAlbany, NY 12206',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'closed': true,
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services': {},
+				primaryContactPerson: primaryContactPerson,
+				'verifiedData': {
+					'address': {
+						'verified': true,
+						'date': '2017-04-16T23:33:17.220Z'
+					}
+				}
+			}
+
+			const primaryContactPerson2 = {
+				firstName: 'Joanna B',
+				lastName: 'Smith',
+				email: 'email2@email.org',
+				phone: '+18884442222',
+				_id: primaryContactPerson._id
+			}
+
+			const newValues = {
+				'address': {
+					'line1': 'New Address',
+					'location': {
+						'type': 'Point',
+						'coordinates': [
+							-73.7814005,
+							42.6722152
+						]
+					},
+				},
+				'prcName': 'Birthright of Albany',
+				'phone': '+15184382978',
+				'website': 'http://www.birthright.org',
+				'services': {},
+				primaryContactPerson: primaryContactPerson2,
+				'verifiedData': {
+					'address': {
+						'verified': true,
+						'date': '2017-04-16T23:33:17.220Z'
+					}
+				}
+			}
+			
+			const oldPCObj = await PregnancyCenterModel.create(oldValues)
+			try {
+				await chai.request(server)
+					.put('/api/pregnancy-centers/' + oldPCObj._id)
+					.send(newValues)
+			} catch (err) {
+				assertError(err.response, 400, 'Bad Request', 'Cannot edit a closed Pregnancy Center')
+			}
 		})
 	})
 

--- a/server/util/database-helpers.js
+++ b/server/util/database-helpers.js
@@ -218,15 +218,15 @@ function validateAndFillFqhc(userId, fqhcObj) {
 	})
 }
 
-function checkIfPregnancyCenterClosed(pregnancyCenterId, newPregnancyCenterObj) {
+function checkIfPregnancyCenterOutOfBusiness(pregnancyCenterId, newPregnancyCenterObj) {
 	return new P( async (resolve, reject) => {
 		try {
-			// if the original document is closed, do not allow updates unless closed is being set to false
+			// if the original document is outOfBusiness, do not allow updates unless outOfBusiness is being set to false
 			const oldPregnancyCenter = await getPregnancyCenterObj(pregnancyCenterId)
 			
-			if (_.get(oldPregnancyCenter, 'closed') // if the original is closed
-				&& (!_.has(newPregnancyCenterObj.closed) || newPregnancyCenterObj.closed)) { // and new is not reopening
-				return reject(new AppValidationError('Cannot edit a closed Pregnancy Center'))
+			if (_.get(oldPregnancyCenter, 'outOfBusiness') // if the original is outOfBusiness
+				&& (!_.has(newPregnancyCenterObj.outOfBusiness) || newPregnancyCenterObj.outOfBusiness)) { // and new is not reopening
+				return reject(new AppValidationError('Cannot edit a outOfBusiness Pregnancy Center'))
 			}
 			return resolve(newPregnancyCenterObj)
 		} catch (err) {
@@ -235,14 +235,14 @@ function checkIfPregnancyCenterClosed(pregnancyCenterId, newPregnancyCenterObj) 
 	})
 }
 
-function checkIfFqhcClosed(fqhcId, newFqhcObj) {
+function checkIfFqhcOutOfBusiness(fqhcId, newFqhcObj) {
 	return new P( async (resolve, reject) => {
 		try {
-			// if the original document is closed, do not allow updates unless closed is being set to false
+			// if the original document is outOfBusiness, do not allow updates unless outOfBusiness is being set to false
 			const oldFqhc = await getOldFqhc(fqhcId)
 			
-			if (_.get(oldFqhc, 'closed') && (!_.has(newFqhcObj.closed) || newFqhcObj.closed)) { 
-				return reject(new AppValidationError('Cannot edit a closed FQHC'))
+			if (_.get(oldFqhc, 'outOfBusiness') && (!_.has(newFqhcObj.outOfBusiness) || newFqhcObj.outOfBusiness)) { 
+				return reject(new AppValidationError('Cannot edit a outOfBusiness FQHC'))
 			}
 			return resolve(newFqhcObj)
 		} catch (err) {
@@ -346,14 +346,14 @@ module.exports = {
 			try {
 				
 				const validate = R.partial(validateAndFillPregnancyCenter, [userId])
-				const checkIfClosed = R.partial(checkIfPregnancyCenterClosed, [pregnancyCenterId])
+				const checkIfOutOfBusiness = R.partial(checkIfPregnancyCenterOutOfBusiness, [pregnancyCenterId])
 				const createUpdateHistory = R.partial(createPregnancyCenterUpdateHistory, 
 					[userId, await getPregnancyCenterObj(pregnancyCenterId)])
 				const updatePregnancyCenter = R.partial(pregnancyCenterFindByIdAndUpdate, [pregnancyCenterId])
 
 				const updateAndSavePregnancyCenter = R.pipeP(
 					validate,
-					checkIfClosed,
+					checkIfOutOfBusiness,
 					makeModelAndPopulate,
 					createUpdateHistory, // side effect of saving history records to the database
 					updatePregnancyCenter,
@@ -371,13 +371,13 @@ module.exports = {
 		return new P(async (resolve, reject) => {
 			try {
 				const validate = R.partial(validateAndFillFqhc, [userId])
-				const checkIfClosed = R.partial(checkIfFqhcClosed, [fqhcId])
+				const checkIfOutOfBusiness = R.partial(checkIfFqhcOutOfBusiness, [fqhcId])
 				const createUpdateHistory = R.partial(createFqhcUpdateHistory, [userId, await getOldFqhc(fqhcId)])
 				const updateFqhc = R.partial(fqhcFindByIdAndUpdate, [fqhcId])
 	
 				const updateAndSaveFqhc = R.pipeP(
 					validate,
-					checkIfClosed,
+					checkIfOutOfBusiness,
 					createUpdateHistory, // side effect of saving update records to the database
 					updateFqhc
 				)


### PR DESCRIPTION
## Description
Adds a 'closed' field to pregnancy centers and FQHCs. `Closed` pregnancy centers and FQHCs cannot be edited until they are reopened, and should not be returned on the front-end unless specifically requested by _id.

## Test Plan
`yarn test`
