### PR TITLE
Adds script to get all pregnancy centers with 'otherServices' filled in

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "connect-mongo": "^1.3.2",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.1",
+    "csv": "^2.0.0",
     "express": "^4.15.3",
     "express-boom": "^2.0.0",
     "express-session": "^1.15.2",

--- a/server/data-import/get-other-services-csv.js
+++ b/server/data-import/get-other-services-csv.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const _ = require('lodash')
+const config = require('config')
+const fs = require('fs')
+const Log = require('log')
+const mongoose = require('mongoose')
+const P = require('bluebird')
+const stringify = require('csv-stringify')
+
+const pregnancyCenterServices = require('../pregnancy-centers/pregnancy-center-services')
+const PregnancyCenterModel = require('../pregnancy-centers/schema/mongoose-schema')
+
+mongoose.Promise = require('bluebird')
+const log = new Log('info')
+
+// TODO: Error handling
+const startDatabase = P.coroutine(function *startDatabase() {
+	yield mongoose.connect(config.mongo.connectionString)
+
+	log.info('Connected to database')
+})
+
+startDatabase()
+
+const mapYesNo = (b) => {
+	if (_.isUndefined(b)) return ''
+	return b ? 'Yes' : 'No'
+}
+
+async function getOtherServicesPregnancyCenters() {
+
+	let data = []
+
+	const services = _.reduce(pregnancyCenterServices, function(obj,service) {
+		obj[service.id] = service.name
+		return obj
+	}, {})
+
+	const columns = _.merge({
+		_id: '_id',
+		prcName: 'Name',
+		note: 'Notes',
+		otherServices: 'Other Services',
+	}, services)
+	
+	const servicesKeys = _.keys(services)
+
+	const pregnancyCenters = await PregnancyCenterModel.find({otherServices:{$ne:null}})
+	for (const pregnancyCenter of pregnancyCenters) {
+		log.info(pregnancyCenter.prcName)
+		const line = [pregnancyCenter._id, pregnancyCenter.prcName, pregnancyCenter.notes || '',
+			pregnancyCenter.otherServices]
+		const servicesValues = _.mapValues(pregnancyCenter.services, mapYesNo)
+		for(const serviceKey of servicesKeys) {
+			line.push(_.get(servicesValues, serviceKey, ''))
+		}
+		data.push(line)
+	}
+	
+	stringify(data, { header: true, columns: columns }, (err, output) => {
+		if (err) {
+			log.error(err)
+			throw err
+		}
+		fs.writeFile('otherservices.csv', output, (err) => {
+			if (err) {
+				log.error(err)
+				throw err
+			}
+			log.info('otherservices.csv saved.')
+			process.exit()
+		})
+	})
+}
+
+getOtherServicesPregnancyCenters()

--- a/server/data-import/get-other-services-csv.js
+++ b/server/data-import/get-other-services-csv.js
@@ -23,9 +23,9 @@ const startDatabase = P.coroutine(function *startDatabase() {
 
 startDatabase()
 
-const mapYesNo = (b) => {
-	if (_.isUndefined(b)) return ''
-	return b ? 'Yes' : 'No'
+const mapYesNo = (booleanValue) => {
+	if (_.isUndefined(booleanValue)) return ''
+	return booleanValue ? 'Yes' : 'No'
 }
 
 async function getOtherServicesPregnancyCenters() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,6 +2320,29 @@ cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0", "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+csv-generate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/csv-generate/-/csv-generate-2.0.0.tgz#ab4fdc30db5ce678b07d53884c69fa545618b25c"
+
+csv-parse@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-2.0.2.tgz#9bb08dd84bb41008a03cde988c07afe0768362f3"
+
+csv-stringify@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-2.0.2.tgz#3d1459fe448a8786d86c87278c2c41961ae173ab"
+  dependencies:
+    lodash.get "~4.4.2"
+
+csv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/csv/-/csv-2.0.0.tgz#0d51d8fa3ece278b5409f795717fcfcd5ace9b3e"
+  dependencies:
+    csv-generate "^2.0.0"
+    csv-parse "^2.0.0"
+    csv-stringify "^2.0.0"
+    stream-transform "^1.0.0"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -4658,7 +4681,7 @@ lodash.deburr@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash.get@4.4.2:
+lodash.get@4.4.2, lodash.get@~4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
@@ -6720,6 +6743,10 @@ stream-http@^2.3.1:
     readable-stream "^2.2.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stream-transform/-/stream-transform-1.0.0.tgz#d4ef386913d6ec102052bc75fc0516947a961f10"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## Description
This script queries the database for all pregnancy centers where `otherServices` exists and is not null. It takes the results and writes them to a csv. The csv contains the PregnancyCenter _id, prcName, notes, otherServices and also the services themselves. There is a column for each service with Yes, No  or blank for each pregnancy center row. 

## Test Plan
run `node get-other-services-csv.js`
