### PR TITLE
Added toggle switch per volunteer take home problem

### DIFF
--- a/client/js/components/toggle.js
+++ b/client/js/components/toggle.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import injectSheet from 'react-jss';
+
+const Toggle = ({classes, toggle, onClick})=>(
+    <div className={classes.toggle}
+         onClick={onClick}
+    >
+        <input type="checkbox"
+               className={classes.toggleSwitch}
+               value={toggle}
+        />
+        <label className={classes.toggleLabel}>
+            <span className={classes.toggleButton}/>
+        </label>
+    </div>
+);
+
+const styles = {
+    toggle: ({toggle})=>({
+        display:'flex',
+        flex: '0 0 100%',
+        justifyContent: 'center',
+        alignItems: 'center',
+        color: (toggle) ? '#F48271' : '#D8D8D8',
+        transition: 'all .3s'
+    }),
+    toggleSwitch:{
+        height: 0,
+        width: 0,
+        visibility: 'hidden'
+    },
+    toggleLabel:{
+        cursor: 'pointer',
+        display: 'inline-block',
+        height: '24px',
+        width: '39px',
+        backgroundColor: 'currentColor',
+        borderRadius: '100px',
+        position: 'relative',
+    },
+    toggleButton: ({toggle})=>({
+        position: 'absolute',
+        top: '1px',
+        left: '1px',
+        boxSizing: 'border-box',
+        width: '22px',
+        height: '22px',
+        backgroundColor:'#fff',
+        border: '2px solid #fff',
+        borderRadius:'100px',
+        transition: 'all .3s',
+        transform: (toggle) ? 'translateX(70%)' : ''
+    })
+};
+
+export default injectSheet(styles)(Toggle);


### PR DESCRIPTION
## Description
Added the toggle switch based on the specification for the take home problem and invision document.

## Test Plan

* Add the component where desired on test page
* The props required to pass in to the component are `toggle` and `onClick` which represent the toggle state and click event
* The `toggle` state is managed by the parent component per the spec and example usage as follows:

```js
//..other dependencies
import Toggle from '../components/Toggle'

export default class someParentComponent extends Component{
    constructor(props){
        super(props);
        this.state = {
            toggle: false
            //other state
        };
    }

    onToggle = (event)=>{
        event.preventDefault();
        this.setState((prevState)=>({
            ...prevState,
            toggle: !prevState.toggle
        }));
    };
    
    render(){
        return(
            <Toggle toggle={this.state.toggle}
                    onClick={this.onToggle}
             />
        );
    }
}
```