### PR TITLE
Add breakpoints to make app responsive

### DIFF
--- a/client/js/components/breakpoints.js
+++ b/client/js/components/breakpoints.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import MediaQuery from 'react-responsive'
+
+const breakpoints = {
+	desktop: '(min-width: 1025px)',
+	tablet: '(min-width: 768px) and (max-width: 1024px)',
+	phone: '(max-width: 767px)',
+}
+
+const Breakpoint = props => {
+	const breakpoint = breakpoints[props.name] || breakpoints.phone
+	console.log('BREAKPOINT PROP', breakpoint)
+
+	return (
+		<MediaQuery {...props} minWidth={700}>
+			{props.children}
+		</MediaQuery>
+	)
+}
+
+export function DesktopBreakpoint(props) {
+	console.log('DESKTOP BREAKPOINT')
+	return <Breakpoint name="desktop">{props.children}</Breakpoint>
+}
+//
+// import Responsive from 'react-responsive';
+//
+// const Desktop = props => <Responsive {...props} minWidth={992} />;
+// const Tablet = props => <Responsive {...props} minWidth={768} maxWidth={991} />;
+// const Mobile = props => <Responsive {...props} maxWidth={767} />;
+// const Default = props => <Responsive {...props} minWidth={768} />;
+//
+// const Example = () => (
+// 	<div>
+// 		<Desktop>Desktop or laptop</Desktop>
+// 		<Tablet>Tablet</Tablet>
+// 		<Mobile>Mobile</Mobile>
+// 		<Default>Not mobile (desktop or laptop or tablet)</Default>
+// 	</div>
+// );
+//
+// export default Example;

--- a/client/js/components/breakpoints.js
+++ b/client/js/components/breakpoints.js
@@ -1,44 +1,15 @@
 import React from 'react'
-import MediaQuery from 'react-responsive'
+import Responsive from 'react-responsive'
 
-const breakpoints = {
-	desktop: '(min-width: 1025px)',
-	tablet: '(min-width: 768px) and (max-width: 1024px)',
-	phone: '(max-width: 767px)',
-}
+const DESKTOP_MIN = 992
+const TABLET_MIN = 768
+const TABLET_MAX = 991
+const PHONE_MAX = 767
 
-const Breakpoint = props => {
-	return (
-		<div>
-			<div>Device Test!</div>
-			<MediaQuery minDeviceWidth={1224}>
-				<div>You are a desktop or laptop</div>
-			</MediaQuery>
-			<MediaQuery maxWidth={1224}>
-				<div>You are sized like a tablet or mobile phone though</div>
-			</MediaQuery>
-			<MediaQuery minDeviceWidth={1824}>
-				<div>You also have a huge screen</div>
-			</MediaQuery>
-			<MediaQuery maxDeviceWidth={1224}>
-				<div>You are a tablet or mobile phone</div>
-			</MediaQuery>
-			<MediaQuery orientation="portrait">
-				<div>You are portrait</div>
-			</MediaQuery>
-			<MediaQuery orientation="landscape">
-				<div>You are landscape</div>
-			</MediaQuery>
-			<MediaQuery minResolution="2dppx">
-				<div>You are retina</div>
-			</MediaQuery>
-		</div>
-	)
-}
+const Desktop = props => <Responsive {...props} minWidth={DESKTOP_MIN} />
+const Tablet = props => (
+	<Responsive {...props} minWidth={TABLET_MIN} maxWidth={TABLET_MAX} />
+)
+const Phone = props => <Responsive {...props} maxWidth={PHONE_MAX} />
 
-export default Breakpoint
-
-// export function DesktopBreakpoint(props) {
-// 	console.log('DESKTOP BREAKPOINT')
-// 	return <Breakpoint name="desktop">{props.children}</Breakpoint>
-// }
+export { Desktop, Tablet, Phone }

--- a/client/js/components/breakpoints.js
+++ b/client/js/components/breakpoints.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import Responsive from 'react-responsive'
 
-const DESKTOP_MIN = 992
+const PHONE_MAX = 767
 const TABLET_MIN = 768
 const TABLET_MAX = 991
-const PHONE_MAX = 767
+const DESKTOP_MIN = 992
 
 const Desktop = props => <Responsive {...props} minWidth={DESKTOP_MIN} />
 const Tablet = props => (

--- a/client/js/components/breakpoints.js
+++ b/client/js/components/breakpoints.js
@@ -8,35 +8,37 @@ const breakpoints = {
 }
 
 const Breakpoint = props => {
-	const breakpoint = breakpoints[props.name] || breakpoints.phone
-	console.log('BREAKPOINT PROP', breakpoint)
-
 	return (
-		<MediaQuery {...props} minWidth={700}>
-			{props.children}
-		</MediaQuery>
+		<div>
+			<div>Device Test!</div>
+			<MediaQuery minDeviceWidth={1224}>
+				<div>You are a desktop or laptop</div>
+			</MediaQuery>
+			<MediaQuery maxWidth={1224}>
+				<div>You are sized like a tablet or mobile phone though</div>
+			</MediaQuery>
+			<MediaQuery minDeviceWidth={1824}>
+				<div>You also have a huge screen</div>
+			</MediaQuery>
+			<MediaQuery maxDeviceWidth={1224}>
+				<div>You are a tablet or mobile phone</div>
+			</MediaQuery>
+			<MediaQuery orientation="portrait">
+				<div>You are portrait</div>
+			</MediaQuery>
+			<MediaQuery orientation="landscape">
+				<div>You are landscape</div>
+			</MediaQuery>
+			<MediaQuery minResolution="2dppx">
+				<div>You are retina</div>
+			</MediaQuery>
+		</div>
 	)
 }
 
-export function DesktopBreakpoint(props) {
-	console.log('DESKTOP BREAKPOINT')
-	return <Breakpoint name="desktop">{props.children}</Breakpoint>
-}
-//
-// import Responsive from 'react-responsive';
-//
-// const Desktop = props => <Responsive {...props} minWidth={992} />;
-// const Tablet = props => <Responsive {...props} minWidth={768} maxWidth={991} />;
-// const Mobile = props => <Responsive {...props} maxWidth={767} />;
-// const Default = props => <Responsive {...props} minWidth={768} />;
-//
-// const Example = () => (
-// 	<div>
-// 		<Desktop>Desktop or laptop</Desktop>
-// 		<Tablet>Tablet</Tablet>
-// 		<Mobile>Mobile</Mobile>
-// 		<Default>Not mobile (desktop or laptop or tablet)</Default>
-// 	</div>
-// );
-//
-// export default Example;
+export default Breakpoint
+
+// export function DesktopBreakpoint(props) {
+// 	console.log('DESKTOP BREAKPOINT')
+// 	return <Breakpoint name="desktop">{props.children}</Breakpoint>
+// }

--- a/client/js/mini-app/view.js
+++ b/client/js/mini-app/view.js
@@ -14,9 +14,14 @@ class MiniApp extends Component {
 	}
 
 	render() {
+		const { classes } = this.props
+
 		return (
 			<div>
-				The Mini App
+				<div className={classes.header}>
+					Made by women, for women to help you make independent, informed
+					healthcare decisions.
+				</div>
 				<MiniAppForm onSubmit={this.submit} />
 			</div>
 		)
@@ -24,8 +29,13 @@ class MiniApp extends Component {
 }
 
 const styles = {
-	root: {
-		height: '0px',
+	header: {
+		'background-color': '#016454',
+		color: '#abd3f9',
+		'font-family': 'sans-serif',
+		'font-size': '30px',
+		height: '104px',
+		padding: '60px 20px 40px 80px',
 	},
 }
 

--- a/client/js/mini-app/view.js
+++ b/client/js/mini-app/view.js
@@ -5,7 +5,6 @@ import { withRouter } from 'react-router-dom'
 
 import MiniAppForm from './form'
 import { getPregnancyResourceCenters } from './data/action-creators'
-import { DesktopBreakpoint } from '../components/breakpoints'
 
 class MiniApp extends Component {
 	submit = ({ locationInput }) => {
@@ -15,15 +14,9 @@ class MiniApp extends Component {
 	}
 
 	render() {
-		const { classes } = this.props
-
 		return (
 			<div>
-				<div className={classes.header}>
-					Made by women, for women to help you make independent, informed
-					healthcare decisions.
-				</div>
-				<DesktopBreakpoint>DESKTOP!!!</DesktopBreakpoint>
+				The Mini App
 				<MiniAppForm onSubmit={this.submit} />
 			</div>
 		)
@@ -31,13 +24,8 @@ class MiniApp extends Component {
 }
 
 const styles = {
-	header: {
-		'background-color': '#016454',
-		color: '#abd3f9',
-		'font-family': 'sans-serif',
-		'font-size': '30px',
-		height: '104px',
-		padding: '60px 20px 40px 80px',
+	root: {
+		height: '0px',
 	},
 }
 

--- a/client/js/mini-app/view.js
+++ b/client/js/mini-app/view.js
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router-dom'
 
 import MiniAppForm from './form'
 import { getPregnancyResourceCenters } from './data/action-creators'
+import { DesktopBreakpoint } from '../components/breakpoints'
 
 class MiniApp extends Component {
 	submit = ({ locationInput }) => {
@@ -22,6 +23,7 @@ class MiniApp extends Component {
 					Made by women, for women to help you make independent, informed
 					healthcare decisions.
 				</div>
+				<DesktopBreakpoint>DESKTOP!!!</DesktopBreakpoint>
 				<MiniAppForm onSubmit={this.submit} />
 			</div>
 		)

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"react-facebook-login": "^3.6.1",
 		"react-jss": "^6.1.1",
 		"react-redux": "^5.0.4",
+		"react-responsive": "^5.0.0",
 		"react-router-dom": "^4.1.1",
 		"react-router-tabs": "^1.2.0",
 		"redux": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2632,6 +2632,10 @@ css-loader@^1.0.0:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
+css-mediaquery@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -3995,6 +3999,10 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
+hyphenate-style-name@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -5215,6 +5223,12 @@ marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
+matchmediaquery@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.3.0.tgz#6f672bcdbc44de16825c6917fbcdcfb9b82607b1"
+  dependencies:
+    css-mediaquery "^0.1.2"
+
 md5.js@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.4.tgz#e9bdbde94a20a5ac18b04340fc5764d5b09d901d"
@@ -6397,6 +6411,14 @@ react-redux@^5.0.4:
     lodash-es "^4.2.0"
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
+
+react-responsive@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-5.0.0.tgz#b6e559b2ce8c4d82b0d47a7a78a74645b977e4af"
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.3.0"
+    prop-types "^15.6.1"
 
 react-router-dom@^4.1.1:
   version "4.2.2"


### PR DESCRIPTION
## Description
This PR adds the `react-responsive` npm package so that we can specify responsive breakpoints and also adds the code to make the necessary breakpoints work.

## Test Plan
1. Add this code to [this file](https://github.com/HelpAssistHer/help-assist-her/blob/master/client/js/mini-app/view.js#L18)

`import { Desktop, Tablet, Phone } from '../components/breakpoints'`
```
<Desktop>
     <div>DESKTOP</div>
</Desktop>
<Tablet>
     <div>TABLET</div>
</Tablet>
<Phone>
     <div>PHONE</div>
</Phone>
```

2. Go to `http://localhost:4000/mini-app`
3. You should initially see the work 'DESKTOP'. Then resize the screen horizontally. As you shrink the screen, you should see the word 'TABLET' appear, and then 'PHONE' as it gets even smaller.