### PR TITLE
Add an "instructions" component to the mini app

### DIFF
--- a/client/js/mini-app/instruction.js
+++ b/client/js/mini-app/instruction.js
@@ -28,7 +28,7 @@ const styles = {
 	instructionRoot: {
 		'text-align': 'center',
 		'font-family': 'sans-serif',
-		'margin-top': '40px',
+		margin: '40px 0px 60px 0px',
 	},
 	stepNumberPhone: {
 		'font-weight': 'bold',

--- a/client/js/mini-app/instruction.js
+++ b/client/js/mini-app/instruction.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import injectSheet from 'react-jss'
+
+import { Phone, Desktop } from '../components/breakpoints'
+
+const Instruction = ({ classes, stepNumber, stepDescription }) => {
+	return (
+		<div className={classes.instructionRoot}>
+			<Phone>
+				<div>
+					<div className={classes.stepNumberPhone}>{stepNumber}</div>
+					<div className={classes.stepDescriptionPhone}>{stepDescription}</div>
+				</div>
+			</Phone>
+			<Desktop>
+				<div>
+					<div className={classes.stepNumberDesktop}>{stepNumber}</div>
+					<div className={classes.stepDescriptionDesktop}>
+						{stepDescription}
+					</div>
+				</div>
+			</Desktop>
+		</div>
+	)
+}
+
+const styles = {
+	instructionRoot: {
+		'text-align': 'center',
+		'font-family': 'sans-serif',
+		'margin-top': '40px',
+	},
+	stepNumberPhone: {
+		'font-weight': 'bold',
+		'font-size': '10px',
+		color: '#3d65f9',
+		'margin-bottom': '20px',
+	},
+	stepDescriptionPhone: {
+		color: '#000000',
+		'font-size': '14px',
+	},
+	stepNumberDesktop: {
+		'font-weight': 'bold',
+		'font-size': '18px',
+		color: '#3d65f9',
+		'margin-bottom': '20px',
+	},
+	stepDescriptionDesktop: {
+		color: '#000000',
+		'font-size': '25px',
+	},
+}
+
+export default injectSheet(styles)(Instruction)

--- a/client/js/mini-app/view.js
+++ b/client/js/mini-app/view.js
@@ -23,6 +23,10 @@ class MiniApp extends Component {
 					stepNumber="STEP ONE"
 					stepDescription="Select one of the following:"
 				/>
+				<Instruction
+					stepNumber="STEP TWO"
+					stepDescription="Enter your location:"
+				/>
 				<MiniAppForm onSubmit={this.submit} />
 			</div>
 		)

--- a/client/js/mini-app/view.js
+++ b/client/js/mini-app/view.js
@@ -6,6 +6,7 @@ import { withRouter } from 'react-router-dom'
 import MiniAppForm from './form'
 import { getPregnancyResourceCenters } from './data/action-creators'
 import Header from './header'
+import Instruction from './instruction'
 
 class MiniApp extends Component {
 	submit = ({ locationInput }) => {
@@ -18,6 +19,10 @@ class MiniApp extends Component {
 		return (
 			<div>
 				<Header />
+				<Instruction
+					stepNumber="STEP ONE"
+					stepDescription="Select one of the following:"
+				/>
 				<MiniAppForm onSubmit={this.submit} />
 			</div>
 		)


### PR DESCRIPTION
## Description
This is a work in progress as we're still finalizing the designs. This PR adds the "instructions" component. If you resize the browser, it also makes the text smaller to fit better on a phone.

## Test Plan
1. Go to http://localhost:4000/mini-app
1. The instructions should look like this: 
<img width="375" alt="screen shot 2018-10-21 at 2 40 43 pm" src="https://user-images.githubusercontent.com/6378435/47272793-70fbb480-d53f-11e8-88a4-e0dfb5764ea3.png">
 
