### PR TITLE
Add a "resource carousel" to the mini app

### DIFF
--- a/client/js/mini-app/components/resource-carousel.js
+++ b/client/js/mini-app/components/resource-carousel.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import _ from 'lodash'
+import injectSheet from 'react-jss'
+
+const resources = ['Community Health Center', 'Pregnancy Resource Center']
+
+const ResourceCarousel = ({ classes }) => {
+	return (
+		<div className={classes.resourceCarouselRoot}>
+			{_.map(resources, resource => {
+				return (
+					<div className={classes.resourceBox} key={resource}>
+						<div className={classes.resourceText}>{resource}</div>
+					</div>
+				)
+			})}
+		</div>
+	)
+}
+
+const styles = {
+	resourceCarouselRoot: {
+		display: 'flex',
+		'justify-content': 'center',
+	},
+	resourceBox: {
+		display: 'flex',
+		'flex-direction': 'column',
+		'justify-content': 'flex-end',
+		height: '241px',
+		width: '261px',
+		'border-left': '3px solid black',
+	},
+	resourceText: {
+		'font-family': 'sans-serif',
+		'font-size': '24px',
+		'text-align': 'center',
+	},
+}
+
+export default injectSheet(styles)(ResourceCarousel)

--- a/client/js/mini-app/components/resource-carousel.js
+++ b/client/js/mini-app/components/resource-carousel.js
@@ -1,15 +1,20 @@
 import React from 'react'
 import _ from 'lodash'
 import injectSheet from 'react-jss'
+import classNames from 'classnames'
 
 const resources = ['Community Health Center', 'Pregnancy Resource Center']
 
 const ResourceCarousel = ({ classes }) => {
 	return (
 		<div className={classes.resourceCarouselRoot}>
-			{_.map(resources, resource => {
+			{_.map(resources, (resource, index) => {
+				const styleWithBorder = classNames(classes.border, classes.resourceBox)
+				const resourceBoxStyle =
+					index === 1 ? styleWithBorder : classes.resourceBox
+
 				return (
-					<div className={classes.resourceBox} key={resource}>
+					<div className={resourceBoxStyle} key={resource}>
 						<div className={classes.resourceText}>{resource}</div>
 					</div>
 				)
@@ -29,12 +34,14 @@ const styles = {
 		'justify-content': 'flex-end',
 		height: '241px',
 		width: '261px',
-		'border-left': '3px solid black',
 	},
 	resourceText: {
 		'font-family': 'sans-serif',
 		'font-size': '24px',
 		'text-align': 'center',
+	},
+	border: {
+		'border-left': '3px solid black',
 	},
 }
 

--- a/client/js/mini-app/view.js
+++ b/client/js/mini-app/view.js
@@ -7,6 +7,7 @@ import MiniAppForm from './form'
 import { getPregnancyResourceCenters } from './data/action-creators'
 import Header from './header'
 import Instruction from './instruction'
+import ResourceCarousel from './components/resource-carousel'
 
 class MiniApp extends Component {
 	submit = ({ locationInput }) => {
@@ -23,6 +24,7 @@ class MiniApp extends Component {
 					stepNumber="STEP ONE"
 					stepDescription="Select one of the following:"
 				/>
+				<ResourceCarousel />
 				<Instruction
 					stepNumber="STEP TWO"
 					stepDescription="Enter your location:"


### PR DESCRIPTION
## Description
This is a work in progress as we're still finalizing the designs. This PR adds the "resource carousel" which is the list of resources that you click on. There isn't any functionality yet (i.e. you can't click it), just the styling (minus icons) has been added.

## Test Plan
1. Go to http://localhost:4000/mini-app
1. The "resource carousel" should look like this:
<img width="647" alt="screen shot 2018-10-21 at 2 53 48 pm" src="https://user-images.githubusercontent.com/6378435/47272916-372bad80-d541-11e8-8c75-702a380cd1e6.png">
