### PR TITLE
rewrite geocode to use ramda and helper functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"passport-facebook-token": "^3.3.0",
 		"preact": "^6.4.0",
 		"preact-compat": "^3.9.3",
-		"ramda": "^0.25.0",
+		"ramda": "0.26.1",
 		"react": "^15.5.4",
 		"react-dom": "^15.5.4",
 		"react-facebook-login": "^3.6.1",

--- a/server/data-import/geocode.js
+++ b/server/data-import/geocode.js
@@ -4,61 +4,50 @@ const config = require('config')
 const Log = require('log')
 const mongoose = require('mongoose')
 const P = require('bluebird')
+const R = require('ramda')
 
 const PregnancyCenterModel = require('../pregnancy-centers/schema/mongoose-schema')
+const {
+	getGoogleGeocode,
+	getLocation,
+	addLocation,
+	saveDoc,
+	getSafeFullAddress,
+} = require('../util/geocode-helpers')
 
-mongoose.Promise = require('bluebird')
+const { safePipeP } = require('../util/ramda-util')
+
+mongoose.Promise = P
 const log = new Log('info')
 
-const googleMapsClient = require('@google/maps').createClient({
-	key: config.googleMaps.key,
-	Promise: P,
-})
+mongoose.connect(config.mongo.connectionString).then(
+	() => {
+		log.info('Connected to database')
+	},
+	err => {
+		log.error(err)
+	},
+)
 
-// TODO: Error handling
-const startDatabase = P.coroutine(function* startDatabase() {
-	yield mongoose.connect(config.mongo.connectionString)
+const geocodeAndSave = async pregnancyCenter => {
+	try {
+		return safePipeP([
+			getSafeFullAddress,
+			getGoogleGeocode,
+			getLocation,
+			R.partial(addLocation, [pregnancyCenter]),
+			saveDoc,
+		])(pregnancyCenter)
+	} catch (err) {
+		log.error(err)
+	}
+}
 
-	log.info('Connected to database')
-})
-
-startDatabase()
-
-// the longitude and latitute of PregnancyCenter are in pc.address.location, which is a GeoJSON point
-// GeoJSON Point: { type: "Point", coordinates: [long, lat] }
-//
-
-// Google's geocoding API has the location part of the result in the format:
-// "location" : {
-//     "lat" : 37.4224764,
-//     "lng" : -122.0842499
-// }
-
-async function geocodePregnancyCenters() {
+const geocodePregnancyCenters = async () => {
 	const pregnancyCenters = await PregnancyCenterModel.find({
 		'address.location': null,
 	})
-	for (const pregnancyCenter of pregnancyCenters) {
-		log.info(pregnancyCenter.prcName)
-		log.info(pregnancyCenter.getFullAddress())
-
-		// Geocode an address.
-		const response = await googleMapsClient
-			.geocode({ address: pregnancyCenter.getFullAddress() })
-			.asPromise()
-		if (response.json.results.length > 0) {
-			const location = response.json.results[0].geometry.location
-
-			log.info(location)
-
-			pregnancyCenter.address.location = {
-				type: 'Point',
-				coordinates: [location.lng, location.lat],
-			}
-			await pregnancyCenter.save()
-		}
-	}
-	process.exit()
+	return Promise.all(pregnancyCenters.map(geocodeAndSave))
 }
 
-geocodePregnancyCenters()
+geocodePregnancyCenters().then(() => process.exit())

--- a/server/util/geocode-helpers.js
+++ b/server/util/geocode-helpers.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const _ = require('lodash')
+const config = require('config')
+const googleMaps = require('@google/maps')
+const R = require('ramda')
+const P = require('bluebird')
+const Log = require('log')
+
+const log = new Log('info')
+
+const googleMapsClient = googleMaps.createClient({
+	key: config.googleMaps.key,
+	Promise: P,
+})
+
+// the longitude and latitute of PregnancyCenter or FQHC are in pc.address.location, which is a GeoJSON point
+// GeoJSON Point: { type: "Point", coordinates: [long, lat] }
+//
+
+// Google's geocoding API has the location part of the result in the format:
+// "location" : {
+//     "lat" : 37.4224764,
+//     "lng" : -122.0842499
+// }
+
+// string => response data as promise
+const getGoogleGeocode = fullAddress =>
+	googleMapsClient.geocode({ address: fullAddress }).asPromise() // a promise
+
+// response => location json or null
+const getLocation = response => {
+	try {
+		return response.json.results[0].geometry.location
+	} catch (err) {
+		log.info('response had no location')
+		return null
+	}
+}
+
+const addLocation = (doc, location) => {
+	doc.address.location = {
+		type: 'Point',
+		coordinates: [location.lng, location.lat],
+	}
+	return doc
+}
+
+const saveDoc = doc => {
+	log.info(`saving ${doc.prcName || doc.fqhcName}`)
+	return doc.save() // a promise
+}
+
+function getFullAddress(doc) {
+	if (_.isUndefined(doc.address)) return ''
+	const getProperty = property => _.get(doc.address, property, '')
+
+	return [
+		getProperty('line1'),
+		getProperty('line2'),
+		getProperty('city'),
+		getProperty('state'),
+		getProperty('zip'),
+	].join(' ')
+}
+
+const getSafeFullAddress = doc => {
+	if (R.isEmpty(doc)) log.info(`doc was empty`)
+	const address = getFullAddress(doc)
+	if (R.isEmpty(address))
+		log.info(`${doc.prcName || doc.fqhCName} has no address`)
+	return address
+}
+
+module.exports = {
+	getGoogleGeocode,
+	getLocation,
+	addLocation,
+	saveDoc,
+	getSafeFullAddress,
+}

--- a/server/util/ramda-util.js
+++ b/server/util/ramda-util.js
@@ -1,0 +1,19 @@
+const R = require('ramda')
+
+const safePipe = R.pipeWith(
+	(f, res) => (R.isNil(res) || R.isEmpty(res) ? res : f(res)),
+)
+
+const safePipeP = R.pipeWith(
+	(f, res) =>
+		R.isNil(res) || R.isEmpty(res) ? res : Promise.resolve(res).then(f),
+)
+
+const then = (f, p) => p.then(f)
+const pipeP = R.pipeWith(then)
+
+module.exports = {
+	pipeP,
+	safePipe,
+	safePipeP,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6446,9 +6446,10 @@ raf@^3.1.0:
   dependencies:
     performance-now "^2.1.0"
 
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+ramda@0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 random-bytes@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description
This PR rewrites the geocode script to better use promises and to use ramda.js. 

## Test Plan
1. Get a fresh copy of the production data locally by running:
`./server/data-import/import-from-prod/prod-to-local.sh`
2. Find one without a location (`{'address.location': null}`), note its id
3. run `yarn geocode`
4. Confirm that the script finishes without error and use the id you saved to confirm that it now is geocoded.
5. Run `yarn test` to ensure there are no regressions.

