### PR TITLE
Adds more tests for near-me, reorganizes tests

### DIFF
--- a/server/test/fqhcs/fqhc-tests.js
+++ b/server/test/fqhcs/fqhc-tests.js
@@ -11,72 +11,23 @@ const mongoose = require('mongoose')
 mongoose.Promise = require('bluebird')
 
 const log = new Log('info')
-const FQHCModel = require('../fqhcs/schema/mongoose-schema')
-const FQHCHistoryModel = require('../fqhc-history/schema/mongoose-schema')
-const server = require('../server')
-const UserModel = require('../users/schema/mongoose-schema')
+const FQHCModel = require('../../fqhcs/schema/mongoose-schema')
+const FQHCHistoryModel = require('../../fqhc-history/schema/mongoose-schema')
+const server = require('../../server')
+const UserModel = require('../../users/schema/mongoose-schema')
 
 chai.use(chaiHttp)
 
-// Allows the middleware to think we're already authenticated.
-async function mockAuthenticate() {
-	server.request.isAuthenticated = function() {
-		return true
-	}
-	try {
-		server.request.user = await UserModel.findOne({ displayName: 'Kate Sills' })
-	} catch (err) {
-		log.err(err)
-	}
-}
-
-// Allows the middleware to think we are *not* authenticated
-function mockUnauthenticate() {
-	server.request.isAuthenticated = function() {
-		return false
-	}
-	server.request.user = null
-}
-
-function assertError(res, statusCode, error, message = null, data = null) {
-	res.should.have.status(statusCode)
-	res.body.should.have.property('statusCode')
-	res.body.should.have.property('error')
-
-	if (message) {
-		res.body.should.have.property('message')
-		res.body.message.should.equal(message)
-	}
-
-	if (data) {
-		res.body.should.have.property('data')
-		res.body.data.should.equal(data)
-	}
-
-	res.body.statusCode.should.equal(statusCode)
-	res.body.error.should.equal(error)
-}
-
-function assertUnauthenticatedError(res) {
-	assertError(res, 401, 'Unauthorized', 'User is not logged in.')
-}
+const {
+	mockAuthenticate,
+	assertUnauthenticatedError,
+	assertError,
+	beforeEachFQHC,
+} = require('../helpers')
 
 //Our parent block
 describe('FQHCs', () => {
-	beforeEach(async () => {
-		//Before each test we empty the database
-		mockUnauthenticate()
-		await FQHCModel.remove({})
-		await UserModel.remove({})
-		const me = new UserModel({
-			displayName: 'Kate Sills',
-		})
-		await me.save()
-		const someoneElse = new UserModel({
-			displayName: 'Someone Else',
-		})
-		await someoneElse.save()
-	})
+	beforeEach(beforeEachFQHC)
 
 	/*
 	 * Test the /GET /api/fqhcs/verify route w/o authentication

--- a/server/test/fqhcs/fqhc-tests.js
+++ b/server/test/fqhcs/fqhc-tests.js
@@ -4,13 +4,11 @@
 const _ = require('lodash')
 const chai = require('chai')
 const chaiHttp = require('chai-http')
-const Log = require('log')
 // eslint-disable-next-line no-unused-vars
 const should = chai.should()
 const mongoose = require('mongoose')
 mongoose.Promise = require('bluebird')
 
-const log = new Log('info')
 const FQHCModel = require('../../fqhcs/schema/mongoose-schema')
 const FQHCHistoryModel = require('../../fqhc-history/schema/mongoose-schema')
 const server = require('../../server')

--- a/server/test/helpers.js
+++ b/server/test/helpers.js
@@ -1,0 +1,110 @@
+'use strict'
+
+//Require the dev-dependencies
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+// eslint-disable-next-line no-unused-vars
+const should = chai.should()
+const Log = require('log')
+const mongoose = require('mongoose')
+mongoose.Promise = require('bluebird')
+
+const log = new Log('info')
+const PregnancyCenterHistoryModel = require('../pregnancy-center-history/schema/mongoose-schema')
+const PregnancyCenterModel = require('../pregnancy-centers/schema/mongoose-schema')
+const server = require('../server')
+const UserModel = require('../users/schema/mongoose-schema')
+const PersonModel = require('../persons/schema/mongoose-schema')
+const FQHCModel = require('../fqhcs/schema/mongoose-schema')
+
+chai.use(chaiHttp)
+
+// Allows the middleware to think we're already authenticated.
+async function mockAuthenticate() {
+	server.request.isAuthenticated = function() {
+		return true
+	}
+	try {
+		server.request.user = await UserModel.findOne({ displayName: 'Kate Sills' })
+	} catch (err) {
+		log.error('ERROR IN MOCKAUTHENTICATE', err)
+	}
+}
+
+// Allows the middleware to think we are *not* authenticated
+function mockUnauthenticate() {
+	server.request.isAuthenticated = function() {
+		return false
+	}
+	server.request.user = null
+}
+
+function assertError(res, statusCode, error, message = null, data = null) {
+	res.should.have.status(statusCode)
+	res.body.should.have.property('statusCode')
+	res.body.should.have.property('error')
+
+	if (message) {
+		res.body.should.have.property('message')
+		res.body.message.should.equal(message)
+	}
+
+	if (data) {
+		res.body.should.have.property('data')
+		res.body.data.should.equal(data)
+	}
+
+	res.body.statusCode.should.equal(statusCode)
+	res.body.error.should.equal(error)
+}
+
+function assertUnauthenticatedError(res) {
+	assertError(res, 401, 'Unauthorized', 'User is not logged in.')
+}
+
+const beforeEachPregnancyCenter = async () => {
+	mockUnauthenticate()
+	await PregnancyCenterModel.remove({})
+	await UserModel.remove({})
+	await PregnancyCenterHistoryModel.remove({})
+	await PersonModel.remove({})
+	const me = new UserModel({
+		displayName: 'Kate Sills',
+	})
+	await me.save()
+	const someoneElse = new UserModel({
+		displayName: 'Someone Else',
+	})
+	await someoneElse.save()
+}
+
+const beforeEachFQHC = async () => {
+	//Before each test we empty the database
+	mockUnauthenticate()
+	await FQHCModel.remove({})
+	await UserModel.remove({})
+	const me = new UserModel({
+		displayName: 'Kate Sills',
+	})
+	await me.save()
+	const someoneElse = new UserModel({
+		displayName: 'Someone Else',
+	})
+	await someoneElse.save()
+}
+
+const importTest = (name, path) => {
+	describe(name, () => {
+		require(path)
+	})
+}
+
+module.exports = {
+	mockAuthenticate,
+	mockUnauthenticate,
+	assertError,
+	assertUnauthenticatedError,
+	beforeEachPregnancyCenter,
+	beforeEachFQHC,
+	importTest,
+}

--- a/server/test/pregnancy-centers/near-me-tests.js
+++ b/server/test/pregnancy-centers/near-me-tests.js
@@ -3,11 +3,9 @@ const chai = require('chai')
 const chaiHttp = require('chai-http')
 // eslint-disable-next-line no-unused-vars
 const should = chai.should()
-const Log = require('log')
 const mongoose = require('mongoose')
 mongoose.Promise = require('bluebird')
 
-const log = new Log('info')
 const PregnancyCenterModel = require('../../pregnancy-centers/schema/mongoose-schema')
 const server = require('../../server')
 const PersonModel = require('../../persons/schema/mongoose-schema')
@@ -318,8 +316,6 @@ describe('/pregnancy-centers/near-me filter combinations', () => {
 			prcName: 'some valid',
 		}
 
-		log.info(pregnancyCenter)
-
 		await PregnancyCenterModel.create(pregnancyCenter)
 
 		await mockAuthenticate()
@@ -349,8 +345,6 @@ describe('/pregnancy-centers/near-me filter combinations', () => {
 			prcName: 'outOfBusiness',
 		}
 
-		log.info(pregnancyCenter)
-
 		await PregnancyCenterModel.create(pregnancyCenter)
 
 		await mockAuthenticate()
@@ -379,8 +373,6 @@ describe('/pregnancy-centers/near-me filter combinations', () => {
 			...doNotList,
 			prcName: 'Do not list',
 		}
-
-		log.info(pregnancyCenter)
 
 		await PregnancyCenterModel.create(pregnancyCenter)
 

--- a/server/test/pregnancy-centers/near-me-tests.js
+++ b/server/test/pregnancy-centers/near-me-tests.js
@@ -1,0 +1,398 @@
+//Require the dev-dependencies
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+// eslint-disable-next-line no-unused-vars
+const should = chai.should()
+const Log = require('log')
+const mongoose = require('mongoose')
+mongoose.Promise = require('bluebird')
+
+const log = new Log('info')
+const PregnancyCenterModel = require('../../pregnancy-centers/schema/mongoose-schema')
+const server = require('../../server')
+const PersonModel = require('../../persons/schema/mongoose-schema')
+
+const { mockAuthenticate, assertError } = require('../helpers')
+
+chai.use(chaiHttp)
+
+/*
+	* Test the GET /api/pregnancy-centers/near-me' route with authentication
+	*/
+describe('/GET /api/pregnancy-centers/near-me', () => {
+	it('it should return an array with only the Birthright of Albany in it, not the Bridge to Life', async () => {
+		const primaryContactPerson = new PersonModel({
+			firstName: 'Joanna',
+			lastName: 'Smith',
+			email: 'email@email.org',
+			phone: '+18884442222',
+		})
+		await primaryContactPerson.save()
+
+		await PregnancyCenterModel.create({
+			address: {
+				line1: '586 Central Ave.\nAlbany, NY 12206',
+				location: {
+					type: 'Point',
+					coordinates: [-73.7814005, 42.6722152],
+				},
+			},
+			primaryContactPerson: primaryContactPerson,
+			prcName: 'Birthright of Albany',
+			phone: '+15184382978',
+			website: 'http://www.birthright.org',
+			services: {},
+			verifiedData: {
+				prcName: {
+					date: new Date('2018-11-15'),
+					verified: true,
+				},
+				address: { verified: true },
+				phone: { verified: true },
+				website: { verified: true },
+			},
+		})
+
+		// copy of above, but outOfBusiness
+		await PregnancyCenterModel.create({
+			address: {
+				line1: '586 Central Ave.\nAlbany, NY 12206',
+				location: {
+					type: 'Point',
+					coordinates: [-73.7814005, 42.6722152],
+				},
+			},
+			outOfBusiness: true,
+			primaryContactPerson: primaryContactPerson,
+			prcName: 'Birthright of Albany - outOfBusiness',
+			phone: '+15184382978',
+			website: 'http://www.birthright.org',
+			services: {},
+			verifiedData: {
+				prcName: {
+					date: new Date('2018-11-15'),
+					verified: true,
+				},
+				address: { verified: true },
+				phone: { verified: true },
+				website: { verified: true },
+			},
+		})
+
+		await PregnancyCenterModel.create({
+			address: {
+				line1: '23-40 Astoria Boulevard\nAstoria, NY 11102',
+				location: {
+					type: 'Point',
+					coordinates: [-73.9241081, 40.771253],
+				},
+			},
+			prcName: 'The Bridge To Life, Inc.',
+			phone: '+17182743577',
+			email: 'thebridgetolife@verizon.net',
+			website: 'http://www.thebridgetolife.org',
+			services: {},
+			verifiedData: {
+				prcName: {
+					date: new Date('2018-11-15'),
+					verified: true,
+				},
+				address: { verified: true },
+				phone: { verified: true },
+				website: { verified: true },
+			},
+		})
+
+		await mockAuthenticate()
+		const res = await chai
+			.request(server)
+			.get(
+				'/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5',
+			)
+
+		res.should.have.status(200)
+		res.body.should.be.a('array')
+		res.body.length.should.be.eql(1)
+		res.body[0].prcName.should.be.eql('Birthright of Albany')
+	})
+})
+
+describe('/pregnancy-centers/near-me', () => {
+	it('the near-me endpoint should only return verified resources', async () => {
+		// Verified before 10-31-18
+		await PregnancyCenterModel.create({
+			address: {
+				line1: '586 Central Ave.\nAlbany, NY 12206',
+				location: {
+					type: 'Point',
+					coordinates: [-73.7814005, 42.6722152],
+				},
+			},
+			prcName: 'Verified before 10-31-18',
+			phone: '+15184382978',
+			website: 'http://www.birthright.org',
+			services: {},
+			verifiedData: {
+				prcName: {
+					date: new Date('2018-08-01'),
+					verified: true,
+				},
+				address: { verified: true },
+				phone: { verified: true },
+				website: { verified: true },
+			},
+		})
+
+		// Verified after 10-31-18
+		await PregnancyCenterModel.create({
+			address: {
+				line1: '586 Central Ave.\nAlbany, NY 12206',
+				location: {
+					type: 'Point',
+					coordinates: [-73.7814005, 42.6722152],
+				},
+			},
+			prcName: 'Verified after 10-31-18',
+			phone: '+15184382978',
+			website: 'http://www.birthright.org',
+			services: {},
+			verifiedData: {
+				prcName: {
+					date: new Date('2018-11-01'),
+					verified: true,
+				},
+				address: { verified: true },
+				phone: { verified: true },
+				website: { verified: true },
+			},
+		})
+
+		// No verification data for prcName
+		await PregnancyCenterModel.create({
+			address: {
+				line1: '586 Central Ave.\nAlbany, NY 12206',
+				location: {
+					type: 'Point',
+					coordinates: [-73.7814005, 42.6722152],
+				},
+			},
+			prcName: 'No verification data for prcName',
+			phone: '+15184382978',
+			website: 'http://www.birthright.org',
+			services: {},
+			verifiedData: {
+				address: { verified: true },
+				phone: { verified: true },
+				website: { verified: true },
+			},
+		})
+
+		await mockAuthenticate()
+		const res = await chai
+			.request(server)
+			.get(
+				'/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5',
+			)
+
+		res.should.have.status(200)
+		res.body.should.be.a('array')
+		res.body.length.should.be.eql(1)
+		res.body[0].prcName.should.be.eql('Verified after 10-31-18')
+	})
+})
+
+/* 
+Right now, results should be shown if...
+- The resource has the name, address, phone, and website verified
+- The name was verified after Oct 31 (this is because we're re-verifying some of the original resources that were verified)
+- The resource is NOT out of business
+- The resource does NOT have Do Not List checked
+
+valid:
+name verified && address verified && phone verified && website
+verified && name verified after oct 31 && ! out of business & ! do not
+list
+*/
+
+const addressVerified = {
+	address: { verified: true },
+}
+
+const phoneVerified = {
+	phone: { verified: true },
+}
+
+const websiteVerified = {
+	website: { verified: true },
+}
+
+const nameVerifiedAfterOct31 = {
+	prcName: {
+		date: new Date('2018-11-15'),
+		verified: true,
+	},
+}
+
+const outOfBusiness = {
+	outOfBusiness: true,
+}
+
+const doNotList = {
+	doNotList: true,
+}
+
+const defaultPregnancyCenter = {
+	address: {
+		line1: '586 Central Ave.\nAlbany, NY 12206',
+		location: {
+			type: 'Point',
+			coordinates: [-73.7814005, 42.6722152],
+		},
+	},
+	prcName: 'Default',
+	phone: '+15184382978',
+	website: 'http://www.birthright.org',
+	services: {},
+}
+
+// These characteristics make up a valid Pregnancy Center
+const verifiedRules = [
+	addressVerified,
+	phoneVerified,
+	websiteVerified,
+	nameVerifiedAfterOct31,
+]
+
+describe('/pregnancy-centers/near-me filter combinations', () => {
+	it('should return this resource that has only valid rules', async () => {
+		let verifiedData = {}
+		for (const rule of verifiedRules) {
+			verifiedData = { ...verifiedData, ...rule }
+		}
+
+		const pregnancyCenter = {
+			...defaultPregnancyCenter,
+			verifiedData: {
+				...verifiedData,
+			},
+			prcName: 'all valid',
+		}
+
+		await PregnancyCenterModel.create(pregnancyCenter)
+
+		await mockAuthenticate()
+		const res = await chai
+			.request(server)
+			.get(
+				'/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5',
+			)
+
+		res.should.have.status(200)
+		res.body.should.be.a('array')
+		res.body.length.should.be.eql(1)
+		res.body[0].prcName.should.be.eql('all valid')
+	})
+
+	it('should not return anything because these are not fully valid', async () => {
+		// Choose at most three of the verified rules at random (some will
+		// be duplicates)
+		let verifiedData = {}
+		verifiedData = {
+			...verifiedData,
+			...verifiedRules[Math.floor(Math.random() * verifiedRules.length)],
+		}
+		verifiedData = {
+			...verifiedData,
+			...verifiedRules[Math.floor(Math.random() * verifiedRules.length)],
+		}
+		verifiedData = {
+			...verifiedData,
+			...verifiedRules[Math.floor(Math.random() * verifiedRules.length)],
+		}
+
+		const pregnancyCenter = {
+			...defaultPregnancyCenter,
+			verifiedData: {
+				...verifiedData,
+			},
+			prcName: 'some valid',
+		}
+
+		log.info(pregnancyCenter)
+
+		await PregnancyCenterModel.create(pregnancyCenter)
+
+		await mockAuthenticate()
+		try {
+			await chai
+				.request(server)
+				.get(
+					'/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5',
+				)
+		} catch (err) {
+			assertError(err.response, 404, 'Not Found')
+		}
+	})
+
+	it('should not return anything because it is OutOfBusiness', async () => {
+		let verifiedData = {}
+		for (const rule of verifiedRules) {
+			verifiedData = { ...verifiedData, ...rule }
+		}
+
+		const pregnancyCenter = {
+			...defaultPregnancyCenter,
+			verifiedData: {
+				...verifiedData,
+			},
+			...outOfBusiness,
+			prcName: 'outOfBusiness',
+		}
+
+		log.info(pregnancyCenter)
+
+		await PregnancyCenterModel.create(pregnancyCenter)
+
+		await mockAuthenticate()
+		try {
+			await chai
+				.request(server)
+				.get(
+					'/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5',
+				)
+		} catch (err) {
+			assertError(err.response, 404, 'Not Found')
+		}
+	})
+
+	it('should not return anything because it is DoNotList', async () => {
+		let verifiedData = {}
+		for (const rule of verifiedRules) {
+			verifiedData = { ...verifiedData, ...rule }
+		}
+
+		const pregnancyCenter = {
+			...defaultPregnancyCenter,
+			verifiedData: {
+				...verifiedData,
+			},
+			...doNotList,
+			prcName: 'Do not list',
+		}
+
+		log.info(pregnancyCenter)
+
+		await PregnancyCenterModel.create(pregnancyCenter)
+
+		await mockAuthenticate()
+		try {
+			await chai
+				.request(server)
+				.get(
+					'/api/pregnancy-centers/near-me?lng=-73.781332&lat=42.6721989&miles=5',
+				)
+		} catch (err) {
+			assertError(err.response, 404, 'Not Found')
+		}
+	})
+})

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -1,11 +1,10 @@
-const importTest = (name, path) => {
-	describe(name, () => {
-		require(path)
-	})
-}
+const { importTest } = require('./helpers')
 
 describe('top', () => {
-	importTest('Pregnancy Center Tests', './pregnancy-center-tests.js')
-	importTest('FQHC Tests', './fqhc-tests.js')
+	importTest(
+		'Pregnancy Center Tests',
+		'./pregnancy-centers/pregnancy-center-tests.js',
+	)
+	importTest('FQHC Tests', './fqhcs/fqhc-tests.js')
 	importTest('Unit Tests', './unit.js')
 })


### PR DESCRIPTION
## Description
This PR adds tests for the `near-me` endpoint, to test whether the following logic holds:

> Right now, results should be shown if...
> - The resource has the name, address, phone, and website verified
> - The name was verified after Oct 31 (this is because we're re-verifying some of the original resources that were verified)
> - The resource is NOT out of business
> - The resource does NOT have Do Not List checked

## Test Plan
npm test, look for near-me
