### PR TITLE
Change Joi schema to allow empty email addresses

### DIFF
--- a/client/js/verification-portal/pregnancy-resource-center/action-creators.js
+++ b/client/js/verification-portal/pregnancy-resource-center/action-creators.js
@@ -56,6 +56,7 @@ export const getResourceToVerify = () => {
 export async function updateResource(updatedResource) {
 	const transformedResource = _.omitBy(
 		{
+			prcName: '',
 			phone: '',
 			hotlinePhoneNumber: '',
 			email: '',

--- a/client/js/verification-portal/pregnancy-resource-center/action-creators.js
+++ b/client/js/verification-portal/pregnancy-resource-center/action-creators.js
@@ -56,6 +56,11 @@ export const getResourceToVerify = () => {
 export async function updateResource(updatedResource) {
 	const transformedResource = _.omitBy(
 		{
+			phone: '',
+			hotlinePhoneNumber: '',
+			email: '',
+			website: '',
+			notes: '',
 			...updatedResource,
 		},
 		_.isNull || _.isUndefined,

--- a/client/js/verification-portal/util.js
+++ b/client/js/verification-portal/util.js
@@ -32,6 +32,10 @@ export const formatPhoneNumber = digits => {
 }
 
 export const parsePhoneNumber = phoneNumber => {
+	if (phoneNumber === '') {
+		return ''
+	}
+
 	//replaces every part of phone number that's not a digit with an empty string
 	return '+1' + phoneNumber.replace(/([\D])/g, '').substr(0, 10)
 }

--- a/server/pregnancy-centers/schema/joi-schema.js
+++ b/server/pregnancy-centers/schema/joi-schema.js
@@ -19,7 +19,9 @@ const pregnancyCenterSchemaJoi = Joi.object({
 	address: addressSchemaJoi,
 	createdAt: Joi.date().iso(),
 	doNotList: Joi.boolean(),
-	email: Joi.string().email(),
+	email: Joi.string()
+		.email()
+		.allow(''),
 	hotlinePhoneNumber: Joi.string()
 		.trim()
 		.regex(/\+1([2-9][0-8][0-9])([2-9][0-9]{2})([0-9]{4})/),

--- a/server/pregnancy-centers/schema/joi-schema.js
+++ b/server/pregnancy-centers/schema/joi-schema.js
@@ -24,18 +24,20 @@ const pregnancyCenterSchemaJoi = Joi.object({
 		.allow(''),
 	hotlinePhoneNumber: Joi.string()
 		.trim()
-		.regex(/\+1([2-9][0-8][0-9])([2-9][0-9]{2})([0-9]{4})/),
+		.regex(/\+1([2-9][0-8][0-9])([2-9][0-9]{2})([0-9]{4})/)
+		.allow(''),
 	hours: hoursSchemaJoi,
 	inVerification: Joi.any()
 		.custom(isObjectId)
 		.allow(null),
 	prcName: Joi.string(),
-	notes: Joi.string(),
-	otherServices: Joi.string(),
+	notes: Joi.string().allow(''),
+	otherServices: Joi.string().allow(''),
 	outOfBusiness: Joi.boolean(),
 	phone: Joi.string()
 		.trim()
-		.regex(/\+1([2-9][0-8][0-9])([2-9][0-9]{2})([0-9]{4})/),
+		.regex(/\+1([2-9][0-8][0-9])([2-9][0-9]{2})([0-9]{4})/)
+		.allow(''),
 	primaryContactPerson: personSchemaJoi,
 	services: helpers.getPregnancyCenterServicesSchema(Joi.boolean()),
 	verifiedData: {
@@ -64,7 +66,7 @@ const pregnancyCenterSchemaJoi = Joi.object({
 		website: dateUserActionSchemaJoi,
 	},
 	updatedAt: Joi.date().iso(),
-	website: Joi.string(),
+	website: Joi.string().allow(''),
 })
 
 module.exports = pregnancyCenterSchemaJoi

--- a/server/test/pregnancy-centers/pregnancy-center-tests.js
+++ b/server/test/pregnancy-centers/pregnancy-center-tests.js
@@ -1731,4 +1731,134 @@ describe('PregnancyCenters', () => {
 			value.inVerification.should.equal(testUser._id)
 		})
 	})
+
+	/*
+	 * Test the Joi validation for pregnancy centers separately from the API routes
+	 */
+	describe('Test Joi validation for pregnancy centers - empty email', () => {
+		it('validation should pass even though email is empty (blank)', async () => {
+			const testPCObj = {
+				email: '',
+			}
+
+			const { error, value } = await pregnancyCenterSchemaJoi.validate(
+				testPCObj,
+				{
+					abortEarly: false,
+				},
+			)
+			if (error) {
+				throw error
+			}
+			value.email.should.equal('')
+		})
+	})
+
+	/*
+	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route
+	 * blank email (i.e. delete email)
+	 */
+	describe.only('/PUT /api/pregnancy-centers/:pregnancyCenterId blank email', () => {
+		it('it should return the updated pregnancyCenter record with deleted email', async () => {
+			await mockAuthenticate()
+
+			const primaryContactPerson = new PersonModel({
+				firstName: 'Joanna',
+				lastName: 'Smith',
+				email: 'email@email.org',
+				phone: '+18884442222',
+			})
+			await primaryContactPerson.save()
+
+			const oldValues = {
+				address: {
+					line1: '586 Central Ave.\nAlbany, NY 12206',
+					location: {
+						type: 'Point',
+						coordinates: [-73.7814005, 42.6722152],
+					},
+				},
+				email: 'myemail@gmail.com',
+				prcName: 'Birthright of Albany',
+				phone: '+15184382978',
+				website: 'http://www.birthright.org',
+				services: {},
+				primaryContactPerson: primaryContactPerson,
+				verifiedData: {
+					address: {
+						verified: true,
+						date: '2017-04-16T23:33:17.220Z',
+					},
+				},
+			}
+
+			const primaryContactPerson2 = {
+				firstName: 'Joanna B',
+				lastName: 'Smith',
+				email: 'email2@email.org',
+				phone: '+18884442222',
+				_id: primaryContactPerson._id,
+			}
+
+			const newValues = {
+				address: {
+					line1: 'New Address',
+					location: {
+						type: 'Point',
+						coordinates: [-73.7814005, 42.6722152],
+					},
+				},
+				email: '',
+				prcName: 'Birthright of Albany',
+				phone: '+15184382978',
+				website: 'http://www.birthright.org',
+				services: {},
+				primaryContactPerson: primaryContactPerson2,
+				verifiedData: {
+					address: {
+						verified: true,
+						date: '2017-04-16T23:33:17.220Z',
+					},
+				},
+			}
+
+			const testUser = await UserModel.findOne({ displayName: 'Kate Sills' })
+
+			const oldPCObj = await PregnancyCenterModel.create(oldValues)
+
+			const res = await chai
+				.request(server)
+				.put('/api/pregnancy-centers/' + oldPCObj._id)
+				.send(newValues)
+
+			res.should.have.status(200)
+			res.body.should.be.a('object')
+			res.body.should.have.property('_id')
+			res.body.should.have.property('prcName')
+			res.body.should.have.property('primaryContactPerson')
+			res.body.should.have.property('email')
+			res.body.email.should.equal('')
+			res.body._id.should.equal(String(oldPCObj._id))
+			res.body.prcName.should.equal('Birthright of Albany')
+			res.body.should.have.property('verifiedData')
+			res.body.should.have.property('updated')
+			res.body.updated.should.have.property('address')
+			res.body.updated.address.should.have.property('userId')
+			res.body.updated.address.userId.should.equal(testUser._id.toString())
+			res.body.verifiedData.should.have.property('address')
+			res.body.verifiedData.address.userId.should.equal(testUser._id.toString())
+
+			// check that the pregnancy center history is created as well.
+			const histories = await PregnancyCenterHistoryModel.find({
+				pregnancyCenterId: oldPCObj._id,
+			})
+			const fields = _.map(histories, 'field')
+			fields.should.have.members([
+				'address',
+				'email',
+				'primaryContactPerson',
+				'verifiedData',
+			])
+		})
+	})
 })

--- a/server/test/pregnancy-centers/pregnancy-center-tests.js
+++ b/server/test/pregnancy-centers/pregnancy-center-tests.js
@@ -1735,10 +1735,16 @@ describe('PregnancyCenters', () => {
 	/*
 	 * Test the Joi validation for pregnancy centers separately from the API routes
 	 */
-	describe('Test Joi validation for pregnancy centers - empty email', () => {
-		it('validation should pass even though email is empty (blank)', async () => {
+	describe('Test Joi validation for pregnancy centers - empty values', () => {
+		it('validation should pass even though values are empty (blank or null)', async () => {
 			const testPCObj = {
 				email: '',
+				hotlinePhoneNumber: '',
+				prcName: 'PRC',
+				notes: '',
+				otherServices: '',
+				phone: '',
+				website: '',
 			}
 
 			const { error, value } = await pregnancyCenterSchemaJoi.validate(
@@ -1756,10 +1762,10 @@ describe('PregnancyCenters', () => {
 
 	/*
 	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route
-	 * blank email (i.e. delete email)
+	 * blank values
 	 */
-	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId blank email', () => {
-		it('it should return the updated pregnancyCenter record with deleted email', async () => {
+	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId blank values', () => {
+		it('it should return the updated pregnancyCenter record with blank values', async () => {
 			await mockAuthenticate()
 
 			const primaryContactPerson = new PersonModel({
@@ -1792,34 +1798,19 @@ describe('PregnancyCenters', () => {
 				},
 			}
 
-			const primaryContactPerson2 = {
-				firstName: 'Joanna B',
-				lastName: 'Smith',
-				email: 'email2@email.org',
-				phone: '+18884442222',
-				_id: primaryContactPerson._id,
-			}
-
 			const newValues = {
 				address: {
-					line1: 'New Address',
+					line1: '586 Central Ave.\nAlbany, NY 12206',
 					location: {
 						type: 'Point',
 						coordinates: [-73.7814005, 42.6722152],
 					},
 				},
 				email: '',
-				prcName: 'Birthright of Albany',
-				phone: '+15184382978',
-				website: 'http://www.birthright.org',
+				prcName: 'PRC',
+				phone: '',
+				website: '',
 				services: {},
-				primaryContactPerson: primaryContactPerson2,
-				verifiedData: {
-					address: {
-						verified: true,
-						date: '2017-04-16T23:33:17.220Z',
-					},
-				},
 			}
 
 			const testUser = await UserModel.findOne({ displayName: 'Kate Sills' })
@@ -1833,20 +1824,18 @@ describe('PregnancyCenters', () => {
 
 			res.should.have.status(200)
 			res.body.should.be.a('object')
+			res.body._id.should.equal(String(oldPCObj._id))
 			res.body.should.have.property('_id')
 			res.body.should.have.property('prcName')
 			res.body.should.have.property('primaryContactPerson')
 			res.body.should.have.property('email')
 			res.body.email.should.equal('')
-			res.body._id.should.equal(String(oldPCObj._id))
-			res.body.prcName.should.equal('Birthright of Albany')
-			res.body.should.have.property('verifiedData')
-			res.body.should.have.property('updated')
+			res.body.prcName.should.equal('PRC')
+			res.body.phone.should.equal('')
+			res.body.website.should.equal('')
 			res.body.updated.should.have.property('address')
 			res.body.updated.address.should.have.property('userId')
 			res.body.updated.address.userId.should.equal(testUser._id.toString())
-			res.body.verifiedData.should.have.property('address')
-			res.body.verifiedData.address.userId.should.equal(testUser._id.toString())
 
 			// check that the pregnancy center history is created as well.
 			const histories = await PregnancyCenterHistoryModel.find({
@@ -1856,7 +1845,9 @@ describe('PregnancyCenters', () => {
 			fields.should.have.members([
 				'address',
 				'email',
-				'primaryContactPerson',
+				'prcName',
+				'phone',
+				'website',
 				'verifiedData',
 			])
 		})

--- a/server/test/pregnancy-centers/pregnancy-center-tests.js
+++ b/server/test/pregnancy-centers/pregnancy-center-tests.js
@@ -1758,7 +1758,7 @@ describe('PregnancyCenters', () => {
 	 * Test the /PUT /api/pregnancy-centers/:pregnancyCenterId route
 	 * blank email (i.e. delete email)
 	 */
-	describe.only('/PUT /api/pregnancy-centers/:pregnancyCenterId blank email', () => {
+	describe('/PUT /api/pregnancy-centers/:pregnancyCenterId blank email', () => {
 		it('it should return the updated pregnancyCenter record with deleted email', async () => {
 			await mockAuthenticate()
 


### PR DESCRIPTION
## Description
I changed the Joi schema to allow empty email addresses. I added two tests (one joi validation, one more of an integration test) to confirm an empty email address is allowed.

## Test Plan
`yarn test` 

1. Click Verify Next Resource until you get a resource that has an email address already populated
1. Remove the email address
1. Save the record
1. View the record in the db and see that it's still there
1. Look at the updated field and see that it hasn't shown an update on the email field
